### PR TITLE
feat: implement DID resolution using Universal Resolver

### DIFF
--- a/inspector-vc/pom.xml
+++ b/inspector-vc/pom.xml
@@ -68,5 +68,10 @@
 			<artifactId>jakarta.json</artifactId>
 			<version>2.0.1</version>
 		</dependency>
+		<dependency>
+			<groupId>decentralized-identity</groupId>
+			<artifactId>uni-resolver-client</artifactId>
+			<version>0.5.0</version>
+		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
This PR implements support for DID Resolution using the Universal Resolver. This enables resolving any DID Method that the universal resolver supports.

It is currently using dev.uniresolver.io for demonstration purposes. It would be inappropriate to continue to use the dev deployment for the validator in production so it's probably worth a discussion of how best to address this, both from a code perspective (i.e. making the universal resolver deployment pointed to configurable) and from an infra perspective.

It's been a while since I've worked in Java. All feedback is welcome.
Thanks.