### PR TITLE
9 validation fails when validating a credential that contains an endorsementjwt

### DIFF
--- a/inspector-vc-web/pom.xml
+++ b/inspector-vc-web/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
         <artifactId>vc-public-validator</artifactId>
-		<version>1.1.0</version>
+		<version>1.1.1</version>
 	</parent>
 	<artifactId>inspector-vc-web</artifactId>
 	<properties>

--- a/inspector-vc/pom.xml
+++ b/inspector-vc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
 		<artifactId>vc-public-validator</artifactId>
-		<version>1.1.0</version>
+		<version>1.1.1</version>
 	</parent>
 	<artifactId>inspector-vc</artifactId>
 	<dependencies>

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/OB30Inspector.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/OB30Inspector.java
@@ -152,6 +152,8 @@ public class OB30Inspector extends VCInspector implements SubInspector {
 				.put(Key.GENERATED_OBJECT_BUILDER, credentialBuilder)
 				.put(Key.PNG_CREDENTIAL_KEY, PngParser.Keys.OB30)
 				.put(Key.SVG_CREDENTIAL_QNAME, SvgParser.QNames.OB30)
+				.put(Key.JWT_CREDENTIAL_NODE_NAME, VerifiableCredential.JWT_NODE_NAME)
+				.put(Key.JWT_CREDENTIAL_ALLOW_WHOLE_PAYLOAD, VerifiableCredential.JWT_ALLOW_WHOLE_PAYLOAD)
 				.put(RunContextKey.DID_RESOLVER, didResolver)
 				.build();
 
@@ -241,7 +243,7 @@ public class OB30Inspector extends VCInspector implements SubInspector {
 				probeCount++;
 				String jwt = node.asText();
 				JsonNode vcNode = fromJwt(jwt, ctx);
-				VerifiableCredential endorsement = credentialBuilder.resource(resource).jsonData(node).jwt(jwt).build();
+				VerifiableCredential endorsement = credentialBuilder.resource(resource).jsonData(vcNode).jwt(jwt).build();
 				accumulator.add(endorsementInspector.run(resource, Map.of(CREDENTIAL_KEY, endorsement)));
 			}
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.1edtech</groupId>
   <artifactId>vc-public-validator</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <name>vc-public-validator</name>
   <packaging>pom</packaging>
   <developers>


### PR DESCRIPTION
This pull request includes several updates to the `inspector-vc` project, including version upgrades and enhancements to the `OB30Inspector` class. The most important changes are summarized below:

### Version Upgrades:
* Updated the version of `vc-public-validator` from `1.1.0` to `1.1.1` in `inspector-vc-web/pom.xml`, `inspector-vc/pom.xml`, and `pom.xml` files. [[1]](diffhunk://#diff-fc5de3c5d9d5ffbbeaa45585389b5da045bc73a03516ebf65c926832239f4429L9-R9) [[2]](diffhunk://#diff-bdb9b1be994556dea665c6690e2b82840b5918025609833003c68d3a17c0e2c1L8-R8) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L10-R10)

### Enhancements to `OB30Inspector`:
* Added new keys to the context map for JWT credentials, including `JWT_CREDENTIAL_NODE_NAME` and `JWT_CREDENTIAL_ALLOW_WHOLE_PAYLOAD`.
* Modified the `endorsement` object creation to use `vcNode` instead of `node` for `jsonData` in the `run` method.