### PR TITLE
Feature/did jwk

### DIFF
--- a/inspector-vc-web/pom.xml
+++ b/inspector-vc-web/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
         <artifactId>vc-public-validator</artifactId>
-		<version>1.1.3</version>
+		<version>1.1.4</version>
 	</parent>
 	<artifactId>inspector-vc-web</artifactId>
 	<properties>

--- a/inspector-vc/pom.xml
+++ b/inspector-vc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
 		<artifactId>vc-public-validator</artifactId>
-		<version>1.1.3</version>
+		<version>1.1.4</version>
 	</parent>
 	<artifactId>inspector-vc</artifactId>
 	<dependencies>

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/did/SimpleDidResolver.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/did/SimpleDidResolver.java
@@ -11,6 +11,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
+import java.util.Base64;
 import java.util.Optional;
 
 public class SimpleDidResolver implements DidResolver {
@@ -22,6 +23,9 @@ public class SimpleDidResolver implements DidResolver {
     // resolve did using universal did resolver
     if (did.getSchemeSpecificPart().startsWith("key:")) {
       builder.publicKeyMultibase(did.getSchemeSpecificPart().substring("key:".length()));
+    } else if (did.getSchemeSpecificPart().startsWith("jwk:")) {
+      byte[] decodedJwk = Base64.getUrlDecoder().decode(did.getSchemeSpecificPart().substring("jwk:".length()));
+      builder.publicKeyJwk(new String(decodedJwk));
     } else if (did.getSchemeSpecificPart().startsWith("web:")) {
       String methodSpecificId = did.getRawSchemeSpecificPart().substring("web:".length());
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.1edtech</groupId>
   <artifactId>vc-public-validator</artifactId>
-  <version>1.1.3</version>
+  <version>1.1.4</version>
   <name>vc-public-validator</name>
   <packaging>pom</packaging>
   <developers>


### PR DESCRIPTION
This pull request includes several updates to the `vc-public-validator` version and enhancements to the `SimpleDidResolver` class. The most important changes are grouped by theme below:

### Version Updates:
* Updated the `vc-public-validator` version from `1.1.3` to `1.1.4` in `inspector-vc-web/pom.xml`.
* Updated the `vc-public-validator` version from `1.1.3` to `1.1.4` in `inspector-vc/pom.xml`.
* Updated the `vc-public-validator` version from `1.1.3` to `1.1.4` in the root `pom.xml`.

### Enhancements to `SimpleDidResolver`:
* Added `Base64` import to `SimpleDidResolver.java` to support decoding JWK.
* Enhanced the `resolve` method in `SimpleDidResolver.java` to handle DIDs with the `jwk:` scheme by decoding the JWK and setting it in the builder.