### PR TITLE
Feature/bitstring status list

### DIFF
--- a/inspector-vc-web/pom.xml
+++ b/inspector-vc-web/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
         <artifactId>vc-public-validator</artifactId>
-		<version>1.1.4</version>
+		<version>1.2.0</version>
 	</parent>
 	<artifactId>inspector-vc-web</artifactId>
 	<properties>

--- a/inspector-vc/pom.xml
+++ b/inspector-vc/pom.xml
@@ -47,15 +47,22 @@
 		<!-- https://github.com/filip26/iron-verifiable-credentials -->
 		<dependency>
 			<groupId>com.apicatalog</groupId>
-			<artifactId>iron-verifiable-credentials-jre8</artifactId>
-			<version>0.7.0</version>
+			<artifactId>iron-verifiable-credentials</artifactId>
+			<version>0.14.0</version>
+		</dependency>
+
+		<!-- https://github.com/filip26/iron-eddsa-rdfc-2022 -->
+		<dependency>
+			<groupId>com.apicatalog</groupId>
+			<artifactId>iron-eddsa-rdfc-2022</artifactId>
+			<version>0.14.0</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/com.apicatalog/titanium-json-ld -->
 		<!-- https://github.com/filip26/titanium-json-ld -->
 		<dependency>
 			<groupId>com.apicatalog</groupId>
 			<artifactId>titanium-json-ld</artifactId>
-			<version>1.3.1</version>
+			<version>1.4.0</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
 		<dependency>

--- a/inspector-vc/pom.xml
+++ b/inspector-vc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
 		<artifactId>vc-public-validator</artifactId>
-		<version>1.1.4</version>
+		<version>1.2.0</version>
 	</parent>
 	<artifactId>inspector-vc</artifactId>
 	<dependencies>

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/BitstringStatusListCredentialInspector.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/BitstringStatusListCredentialInspector.java
@@ -1,0 +1,100 @@
+package org.oneedtech.inspect.vc;
+
+import static org.oneedtech.inspect.core.report.ReportUtil.onProbeException;
+import static org.oneedtech.inspect.util.json.ObjectMapperCache.Config.DEFAULT;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.oneedtech.inspect.core.probe.Probe;
+import org.oneedtech.inspect.core.probe.RunContext;
+import org.oneedtech.inspect.core.probe.RunContext.Key;
+import org.oneedtech.inspect.core.probe.json.JsonPathEvaluator;
+import org.oneedtech.inspect.core.report.Report;
+import org.oneedtech.inspect.core.report.ReportItems;
+import org.oneedtech.inspect.util.json.ObjectMapperCache;
+import org.oneedtech.inspect.util.resource.Resource;
+import org.oneedtech.inspect.util.resource.ResourceType;
+import org.oneedtech.inspect.util.spec.Specification;
+import org.oneedtech.inspect.vc.VerifiableCredential.Type;
+import org.oneedtech.inspect.vc.probe.ContextPropertyProbe;
+import org.oneedtech.inspect.vc.probe.CredentialParseProbe;
+import org.oneedtech.inspect.vc.probe.CredentialSubjectProbe;
+import org.oneedtech.inspect.vc.probe.EmbeddedProofProbe;
+import org.oneedtech.inspect.vc.probe.TypePropertyProbe;
+
+public class BitstringStatusListCredentialInspector extends VCInspector {
+  protected BitstringStatusListCredentialInspector(
+      BitstringStatusListCredentialInspector.Builder builder) {
+    super(builder);
+  }
+
+  @Override
+  public Report run(Resource resource) {
+    super.check(resource);
+
+    ObjectMapper mapper = ObjectMapperCache.get(DEFAULT);
+    JsonPathEvaluator jsonPath = new JsonPathEvaluator(mapper);
+
+    RunContext ctx =
+        new RunContext.Builder()
+            .put(this)
+            .put(resource)
+            .put(Key.JACKSON_OBJECTMAPPER, mapper)
+            .put(Key.JSONPATH_EVALUATOR, jsonPath)
+            .put(Key.GENERATED_OBJECT_BUILDER, new VerifiableCredential.Builder())
+            .build();
+
+    List<ReportItems> accumulator = new ArrayList<>();
+    int probeCount = 0;
+
+    try {
+      // detect type (png, svg, json, jwt) and extract json data
+      probeCount++;
+      accumulator.add(new CredentialParseProbe().run(resource, ctx));
+      if (broken(accumulator, true)) return abort(ctx, accumulator, probeCount);
+
+      // we expect the above to place a generated object in the context
+      VerifiableCredential bslCred = ctx.getGeneratedObject(VerifiableCredential.ID);
+
+      // context and type
+      VerifiableCredential.Type type = Type.BitstringStatusListCredential;
+      for (Probe<JsonNode> probe :
+          List.of(new ContextPropertyProbe(type), new TypePropertyProbe(type))) {
+        probeCount++;
+        accumulator.add(probe.run(bslCred.getJson(), ctx));
+        if (broken(accumulator)) return abort(ctx, accumulator, probeCount);
+      }
+
+      // credentialSubject
+      probeCount++;
+      accumulator.add(
+          new CredentialSubjectProbe("BitstringStatusList", false).run(bslCred.getJson(), ctx));
+
+      // proof
+      probeCount++;
+      accumulator.add(new EmbeddedProofProbe().run(bslCred, ctx));
+
+      // add the credential as a generated object
+      accumulator.add(new ReportItems(Collections.emptyList(), List.of(bslCred)));
+
+    } catch (Exception e) {
+      accumulator.add(onProbeException(Probe.ID.NO_UNCAUGHT_EXCEPTIONS, resource, e));
+    }
+
+    return new Report(ctx, new ReportItems(accumulator), probeCount);
+  }
+
+  public static class Builder
+      extends VCInspector.Builder<BitstringStatusListCredentialInspector.Builder> {
+    @SuppressWarnings("unchecked")
+    @Override
+    public BitstringStatusListCredentialInspector build() {
+      set(Specification.OB30);
+      set(ResourceType.OPENBADGE);
+      return new BitstringStatusListCredentialInspector(this);
+    }
+  }
+}

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/VerifiableCredential.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/VerifiableCredential.java
@@ -8,8 +8,6 @@ import static org.oneedtech.inspect.vc.VerifiableCredential.Type.VerifiablePrese
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
-
-import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -52,7 +50,7 @@ public class VerifiableCredential extends Credential {
   }
 
   public VCVersion getVersion() {
-      return version;
+    return version;
   }
 
   private static final Map<CredentialEnum, SchemaKey> schemas =
@@ -63,9 +61,10 @@ public class VerifiableCredential extends Credential {
           .put(EndorsementCredential, Catalog.OB_30_ANY_ENDORSEMENTCREDENTIAL_JSON)
           .build();
 
-    public static final String JSONLD_CONTEXT_W3C_CREDENTIALS_V2 = "https://www.w3.org/ns/credentials/v2";
+  public static final String JSONLD_CONTEXT_W3C_CREDENTIALS_V2 =
+      "https://www.w3.org/ns/credentials/v2";
 
-    private static final Map<Set<VerifiableCredential.Type>, List<String>> contextMap =
+  private static final Map<Set<VerifiableCredential.Type>, List<String>> contextMap =
       new ImmutableMap.Builder<Set<VerifiableCredential.Type>, List<String>>()
           .put(
               Set.of(Type.OpenBadgeCredential, AchievementCredential, EndorsementCredential),
@@ -78,6 +77,9 @@ public class VerifiableCredential extends Credential {
                   JSONLD_CONTEXT_W3C_CREDENTIALS_V2,
                   "https://purl.imsglobal.org/spec/clr/v2p0/context-2.0.1.json",
                   "https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json"))
+          .put(
+              Set.of(Type.BitstringStatusListCredential),
+              List.of(JSONLD_CONTEXT_W3C_CREDENTIALS_V2))
           .build();
 
   private static final Map<String, List<String>> contextAliasesMap =
@@ -90,9 +92,7 @@ public class VerifiableCredential extends Credential {
           .put(
               "https://purl.imsglobal.org/spec/clr/v2p0/context-2.0.1.json",
               List.of("https://purl.imsglobal.org/spec/clr/v2p0/context.json"))
-          .put(
-              JSONLD_CONTEXT_W3C_CREDENTIALS_V2,
-              List.of("https://www.w3.org/2018/credentials/v1"))
+          .put(JSONLD_CONTEXT_W3C_CREDENTIALS_V2, List.of("https://www.w3.org/2018/credentials/v1"))
           .build();
 
   private static final Map<String, List<String>> contextVersioningPatternMap =
@@ -118,6 +118,7 @@ public class VerifiableCredential extends Credential {
     VerifiablePresentation(Collections.emptyList()),
     VerifiableCredential(
         List.of("VerifiableCredential")), // this is an underspecifier in our context
+    BitstringStatusListCredential(List.of("BitstringStatusListCredential")),
     Unknown(Collections.emptyList());
 
     private final List<String> allowedTypeValues;
@@ -138,6 +139,8 @@ public class VerifiableCredential extends Credential {
             return VerifiablePresentation;
           } else if (value.equals("EndorsementCredential")) {
             return EndorsementCredential;
+          } else if (value.equals("BitstringStatusListCredential")) {
+            return BitstringStatusListCredential;
           }
         }
       }
@@ -205,10 +208,10 @@ public class VerifiableCredential extends Credential {
     }
 
     static VCVersion of(JsonNode context) {
-      if (JsonNodeUtil.asNodeList(context)
-			.stream()
-			.anyMatch(node -> node.isTextual() && node.asText().equals(JSONLD_CONTEXT_W3C_CREDENTIALS_V2)) )
-      return VCDMv2p0;
+      if (JsonNodeUtil.asNodeList(context).stream()
+          .anyMatch(
+              node -> node.isTextual() && node.asText().equals(JSONLD_CONTEXT_W3C_CREDENTIALS_V2)))
+        return VCDMv2p0;
 
       return VCDMv1p1;
     }
@@ -219,12 +222,7 @@ public class VerifiableCredential extends Credential {
     public VerifiableCredential build() {
       VCVersion version = VCVersion.of(getJsonData().get("@context"));
 
-      return new VerifiableCredential(
-          getResource(),
-          getJsonData(),
-          getJwt(),
-          schemas,
-          version);
+      return new VerifiableCredential(getResource(), getJsonData(), getJwt(), schemas, version);
     }
   }
 

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/EmbeddedProofProbe.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/EmbeddedProofProbe.java
@@ -20,9 +20,9 @@ import org.oneedtech.inspect.vc.verification.URDNA2015Canonicalizer;
 import com.apicatalog.jsonld.StringUtils;
 import com.apicatalog.jsonld.document.Document;
 import com.apicatalog.jsonld.loader.DocumentLoaderOptions;
-import com.apicatalog.multibase.Multibase;
-import com.apicatalog.multicodec.Multicodec;
-import com.apicatalog.multicodec.Multicodec.Codec;
+import com.apicatalog.multibase.MultibaseDecoder;
+import com.apicatalog.multicodec.MulticodecDecoder;
+import com.apicatalog.multicodec.codec.KeyCodec;
 
 import info.weboftrust.ldsignatures.LdProof;
 import info.weboftrust.ldsignatures.canonicalizer.Canonicalizer;
@@ -157,7 +157,7 @@ public class EmbeddedProofProbe extends Probe<VerifiableCredential> {
     // https://w3c-ccg.github.io/di-eddsa-2020/#ed25519verificationkey2020
     byte[] publicKeyMulticodec;
     try {
-      publicKeyMulticodec = Multibase.decode(publicKeyMultibase);
+      publicKeyMulticodec = MultibaseDecoder.getInstance().decode(publicKeyMultibase);
       if (publicKeyMulticodec[0] != (byte) 0xed || publicKeyMulticodec[1] != (byte) 0x01) {
         return error("Verification method does not contain an Ed25519 public key", ctx);
       }
@@ -174,7 +174,7 @@ public class EmbeddedProofProbe extends Probe<VerifiableCredential> {
     }
 
     // Extract the publicKey bytes from the Multicodec
-    byte[] publicKey = Multicodec.decode(Codec.Ed25519PublicKey, publicKeyMulticodec);
+    byte[] publicKey = MulticodecDecoder.getInstance(KeyCodec.ED25519_PUBLIC_KEY).decode(publicKeyMulticodec);
 
     // choose verifier
     LdVerifier<?> verifier = getVerifier(proof, publicKey, crd);
@@ -211,8 +211,8 @@ public class EmbeddedProofProbe extends Probe<VerifiableCredential> {
 
   private Boolean IsValidPublicKeyMultibase(String publicKeyMultibase) {
     try {
-      byte[] publicKeyMulticodec = Multibase.decode(publicKeyMultibase);
-      byte[] publicKey = Multicodec.decode(Codec.Ed25519PublicKey, publicKeyMulticodec);
+      byte[] publicKeyMulticodec = MultibaseDecoder.getInstance().decode(publicKeyMultibase);
+      byte[] publicKey = MulticodecDecoder.getInstance(KeyCodec.ED25519_PUBLIC_KEY).decode(publicKeyMulticodec);
       return publicKey.length == 32;
     } catch (Exception e) {
       return false;

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/RevocationListProbe.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/RevocationListProbe.java
@@ -2,83 +2,116 @@ package org.oneedtech.inspect.vc.probe;
 
 import static org.oneedtech.inspect.core.probe.RunContext.Key.JACKSON_OBJECTMAPPER;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.util.List;
-
 import org.oneedtech.inspect.core.probe.Probe;
 import org.oneedtech.inspect.core.probe.RunContext;
 import org.oneedtech.inspect.core.report.ReportItems;
 import org.oneedtech.inspect.util.resource.MimeType;
 import org.oneedtech.inspect.vc.Credential;
-import org.oneedtech.inspect.vc.VerifiableCredential;
+import org.oneedtech.inspect.vc.status.bitstring.BitstringStatusListProbe;
 import org.oneedtech.inspect.vc.util.JsonNodeUtil;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * A Probe that verifies a credential's revocation status.
+ *
  * @author mgylling
  */
 public class RevocationListProbe extends Probe<Credential> {
 
-	public RevocationListProbe() {
-		super(ID);
-	}
+  public RevocationListProbe() {
+    super(ID);
+  }
 
-	@Override
-	public ReportItems run(Credential crd, RunContext ctx) throws Exception {
+  @Override
+  public ReportItems run(Credential crd, RunContext ctx) throws Exception {
 
-		/*
-		 *	If the AchievementCredential or EndorsementCredential has a “credentialStatus” property
-		 *	and the type of the CredentialStatus object is “1EdTechRevocationList”, fetch the
-		 *	credential status from the URL provided. If the request is unsuccessful,
-		 *	report a warning, not an error.
-		 */
+    /*
+     *	If the AchievementCredential or EndorsementCredential has a “credentialStatus” property
+     *	and the type of the CredentialStatus object is “1EdTechRevocationList”, fetch the
+     *	credential status from the URL provided. If the request is unsuccessful,
+     *	report a warning, not an error.
+     *
+     *	If the AchievementCredential or EndorsementCredential has a “credentialStatus” property
+     *	and the type of the CredentialStatus object is BitstringStatusListEntry, fetch the
+     *	credential status following Bitstring Status List
+     * https://w3c.github.io/vc-bitstring-status-list
+     */
 
-		JsonNode credentialStatus = crd.getJson().get("credentialStatus");
-		if(credentialStatus != null) {
-			JsonNode type = credentialStatus.get("type");
-			if(type != null && type.asText().strip().equals("1EdTechRevocationList")) {
-				JsonNode listID = credentialStatus.get("id");
-				if(listID != null) {
-					try {
-						URL url = new URI(listID.asText().strip()).toURL();
-						HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-						connection.setRequestProperty("Accept", MimeType.JSON.toString());
-						try (InputStream is = connection.getInputStream()) {
-					        JsonNode revocList = ((ObjectMapper)ctx.get(JACKSON_OBJECTMAPPER)).readTree(is.readAllBytes());
+    String credentialId = crd.getJson().get("id").asText();
+    JsonNode credentialStatus = crd.getJson().get("credentialStatus");
+    if (credentialStatus != null) {
+      if (credentialStatus.isArray()) {
+        for (JsonNode status : credentialStatus) {
+          ReportItems report = checkStatus(status, credentialId, ctx);
+          if (report != null) {
+            return report;
+          }
+        }
+      } else {
+        ReportItems status = checkStatus(credentialStatus, credentialId, ctx);
+        if (status != null) {
+          return status;
+        }
+      }
+    }
+    return success(ctx);
+  }
 
-					        /* To check if a credential has been revoked, the verifier issues a GET request
-					         * to the URL of the issuer's 1EdTech Revocation List Status Method. If the
-					         * credential's id is in the list of revokedCredentials and the value of
-					         * revoked is true or ommitted, the issuer has revoked the credential. */
+  private ReportItems checkStatus(JsonNode credentialStatus, String credentialId, RunContext ctx)
+      throws Exception {
+    JsonNode type = credentialStatus.get("type");
+    if (type == null) {
+      return null;
+    }
+    if (type.asText().strip().equals("1EdTechRevocationList")) {
+      JsonNode listID = credentialStatus.get("id");
+      if (listID != null) {
+        try {
+          URL url = new URI(listID.asText().strip()).toURL();
+          HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+          connection.setRequestProperty("Accept", MimeType.JSON.toString());
+          try (InputStream is = connection.getInputStream()) {
+            JsonNode revocList =
+                ((ObjectMapper) ctx.get(JACKSON_OBJECTMAPPER)).readTree(is.readAllBytes());
 
-					        JsonNode crdID = crd.getJson().get("id"); //TODO these != checks sb removed (trigger warning)
-					        if(crdID != null) {
-					        	List<JsonNode> list = JsonNodeUtil.asNodeList(revocList.get("revokedCredential"));
-					        	if(list != null) {
-					        		for(JsonNode item : list) {
-					        			JsonNode revID = item.get("id");
-					        			JsonNode revoked = item.get("revoked");
-					        			if(revID != null && revID.equals(crdID) && (revoked == null || revoked.asBoolean())) {
-					        				return fatal("Credential has been revoked", ctx);
-					        			}
-					        		}
-					        	}
-					        }
-						}
-					} catch (Exception e) {
-						return warning("Error when fetching credentialStatus resource " + e.getMessage(), ctx);
-					}
-				}
-			}
-		}
-		return success(ctx);
-	}
+            /* To check if a credential has been revoked, the verifier issues a GET request
+             * to the URL of the issuer's 1EdTech Revocation List Status Method. If the
+             * credential's id is in the list of revokedCredentials and the value of
+             * revoked is true or ommitted, the issuer has revoked the credential. */
 
-	public static final String ID = RevocationListProbe.class.getSimpleName();
+            if (credentialId != null) {
+              List<JsonNode> list = JsonNodeUtil.asNodeList(revocList.get("revokedCredential"));
+              if (list != null) {
+                for (JsonNode item : list) {
+                  String revID = item.get("id").asText();
+                  JsonNode revoked = item.get("revoked");
+                  if (revID != null
+                      && revID.equals(credentialId)
+                      && (revoked == null || revoked.asBoolean())) {
+                    return fatal("Credential has been revoked", ctx);
+                  }
+                }
+              }
+            }
+          }
+        } catch (Exception e) {
+          return warning("Error when fetching credentialStatus resource " + e.getMessage(), ctx);
+        }
+      }
+    } else if (type.asText().strip().equals("BitstringStatusListEntry")) {
+      if (credentialStatus.hasNonNull("statusPurpose")
+          && credentialStatus.get("statusPurpose").asText().strip().equals("revocation")) {
+        return new BitstringStatusListProbe().run(credentialStatus, ctx);
+      }
+    }
+    return null;
+  }
+
+  public static final String ID = RevocationListProbe.class.getSimpleName();
 }

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/validation/ValidationPropertyProbe.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/validation/ValidationPropertyProbe.java
@@ -4,8 +4,6 @@ import static org.oneedtech.inspect.vc.Assertion.ValueType.DATA_URI;
 import static org.oneedtech.inspect.vc.Assertion.ValueType.DATA_URI_OR_URL;
 import static org.oneedtech.inspect.vc.Assertion.ValueType.URL;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -23,13 +21,10 @@ import org.oneedtech.inspect.vc.jsonld.JsonLdGeneratedObject;
 import org.oneedtech.inspect.vc.jsonld.probe.JsonLDCompactionProve;
 import org.oneedtech.inspect.vc.probe.PropertyProbe;
 import org.oneedtech.inspect.vc.resource.UriResourceFactory;
-import org.oneedtech.inspect.vc.util.CachingDocumentLoader;
 import org.oneedtech.inspect.vc.util.JsonNodeUtil;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import foundation.identity.jsonld.ConfigurableDocumentLoader;
 
 /**
  * Validator for properties of type other than ValueType.RDF_TYPE in Open Badges 2.0 types

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/status/bitstring/BitstringStatusListProbe.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/status/bitstring/BitstringStatusListProbe.java
@@ -1,0 +1,162 @@
+package org.oneedtech.inspect.vc.status.bitstring;
+
+import com.apicatalog.multibase.MultibaseDecoder;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.zip.GZIPInputStream;
+import org.oneedtech.inspect.core.probe.Outcome;
+import org.oneedtech.inspect.core.probe.Probe;
+import org.oneedtech.inspect.core.probe.RunContext;
+import org.oneedtech.inspect.core.report.Report;
+import org.oneedtech.inspect.core.report.ReportItems;
+import org.oneedtech.inspect.util.resource.MimeType;
+import org.oneedtech.inspect.util.resource.UriResource;
+import org.oneedtech.inspect.vc.BitstringStatusListCredentialInspector;
+import org.oneedtech.inspect.vc.VerifiableCredential;
+
+/**
+ * Follows algorithm defined at https://w3c.github.io/vc-bitstring-status-list/#validate-algorithm
+ */
+public class BitstringStatusListProbe extends Probe<JsonNode> {
+
+  @Override
+  public ReportItems run(JsonNode credentialStatus, RunContext ctx) {
+    // 2. Let minimumNumberOfEntries be 131,072 unless a different lower bound is established by a
+    // specific ecosystem specification.
+    int minimumNumberOfEntries = 131_072;
+
+    // 3. Let status purpose be the value of statusPurpose in the credentialStatus entry in the
+    // credentialToValidate.
+    String statusPurpose = credentialStatus.get("statusPurpose").asText().strip();
+
+    int statusSize =
+        credentialStatus.hasNonNull("statusSize")
+            ? credentialStatus.get("statusSize").asInt()
+            : 1; // indicates the size of the status entry in bits
+    if (statusSize < 0) {
+      return error("statusSize must be a non-negative integer", ctx);
+    }
+
+    // 4. Dereference the statusListCredential URL, and ensure that all proofs verify successfully
+    URI statusListCredentialUrl;
+    try {
+      statusListCredentialUrl = new URI(credentialStatus.get("statusListCredential").asText());
+    } catch (Exception e) {
+      return error("statusListCredential is not a valid URI", ctx);
+    }
+    UriResource uriResource =
+        new UriResource(statusListCredentialUrl, null, List.of(MimeType.JSON, MimeType.JSON_LD));
+
+    BitstringStatusListCredentialInspector inspector =
+        new BitstringStatusListCredentialInspector.Builder().build();
+    Report report = inspector.run(uriResource);
+    if (report.getOutcome() != Outcome.VALID) {
+      // the credential is not valid, return inspector report
+      return new ReportItems(report);
+    }
+
+    Optional<VerifiableCredential> statusListCredentialMaybe =
+        report.getGeneratedObject(VerifiableCredential.ID);
+    if (statusListCredentialMaybe.isEmpty()) {
+      return exception("BitstringStatusListCredential not found in report", uriResource);
+    }
+    VerifiableCredential statusListCredential = statusListCredentialMaybe.get();
+
+    // 5. Verify that the status purpose is equal to a statusPurpose value in the
+    // statusListCredential.
+    JsonNode credentialSubject = statusListCredential.getJson().get("credentialSubject");
+    if (!credentialSubject.get("statusPurpose").asText().strip().equals(statusPurpose)) {
+      return error(
+          "statusPurpose mismatch (credential: "
+              + statusPurpose
+              + ", bitstringStatusListCredential: "
+              + credentialSubject.get("statusPurpose").asText().strip(),
+          ctx);
+    }
+
+    // 6. Let compressed bitstring be the value of the encodedList property of the
+    // BitstringStatusListCredential.
+    String encodedList = credentialSubject.get("encodedList").asText();
+    if (encodedList == null || encodedList.isEmpty()) {
+      return error("encodedList is empty", ctx);
+    }
+
+    // 7. Let credentialIndex be the value of the statusListIndex property of the
+    // BitstringStatusListEntry.
+    int credentialIndex = credentialStatus.get("statusListIndex").asInt();
+
+    // 8. Generate a revocation bitstring by passing compressed bitstring to the Bitstring Expansion
+    // Algorithm.
+    try {
+      byte[] revocationBitString = expand(encodedList);
+
+      // 9. If the length of the revocation bitstring divided by statusSize is less than
+      // minimumNumberOfEntries, raise a STATUS_LIST_LENGTH_ERROR.
+      if ((revocationBitString.length * 8 / statusSize) < minimumNumberOfEntries) {
+        return error("revocation bitstring length is less than minimumNumberOfEntries", ctx);
+      }
+
+      // 10. Let status be the value in the bitstring at the position indicated by the
+      // credentialIndex
+      // multiplied by the size. If the credentialIndex multiplied by the size is a value outside of
+      // the range of the bitstring, a RANGE_ERROR MUST be raised.
+      int index = credentialIndex * statusSize;
+      if (index >= revocationBitString.length) {
+        return error(
+            "credentialIndex multiplied by the size is a value outside of the range of the"
+                + " bitstring",
+            ctx);
+      }
+      int byteIndex = index / 8; // Find the byte index
+      int bitPosition = index % 8; // Find the bit within the byte
+      byte byteValue = revocationBitString[byteIndex];
+
+      // printl bytevalue in hexadecimal
+      System.out.println("Byte value in hexadecimal: " + Integer.toHexString(byteValue));
+      // find the position in revocationBitString where its value is different than zero and print it
+      for (int i = 0; i < revocationBitString.length; i++) {
+        if (revocationBitString[i] != 0) {
+          System.out.println("Position in revocationBitString where its value is different than zero: " + i + " = " + revocationBitString[i]);
+          break;
+        }
+      }
+
+      // Calculate the mask for the bit we are interested in
+      int bitMask = 1 << (7 - bitPosition); // Left-to-right indexing (MSB is 0th bit)
+      // Check if the bit is set (non-zero value)
+      if ((byteValue & bitMask) != 0) {
+        return fatal("Credential has been revoked", ctx);
+      }
+      return success(ctx);
+
+    } catch (IOException e) {
+      return fatal("Error expanding bitstring:" + e.getLocalizedMessage(), ctx);
+    }
+  }
+
+  private byte[] expand(String encodedList) throws IOException {
+
+    // 2. Generate an uncompressed bitstring by using the Multibase-decode algorithm on the
+    // compressed bitstring and
+    // then expanding the output using the GZIP decompression algorithm [RFC1952].
+    byte[] decodedBitstring = MultibaseDecoder.getInstance().decode(encodedList);
+
+    // ungzip decodedBitstring
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(decodedBitstring);
+    GZIPInputStream gzipInputStream = new GZIPInputStream(byteArrayInputStream);
+    byte[] buffer = new byte[1024];
+    int bytesRead;
+    ByteArrayOutputStream decompressedStream = new ByteArrayOutputStream();
+    while ((bytesRead = gzipInputStream.read(buffer)) != -1) {
+      decompressedStream.write(buffer, 0, bytesRead);
+    }
+    return decompressedStream.toByteArray();
+  }
+
+  public static final String ID = BitstringStatusListProbe.class.getSimpleName();
+}

--- a/inspector-vc/src/test/java/org/oneedtech/inspect/vc/BitstringStatusListCredentialInspectorTest.java
+++ b/inspector-vc/src/test/java/org/oneedtech/inspect/vc/BitstringStatusListCredentialInspectorTest.java
@@ -1,0 +1,34 @@
+package org.oneedtech.inspect.vc;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.oneedtech.inspect.test.Assertions.assertValid;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.oneedtech.inspect.core.Inspector.Behavior;
+import org.oneedtech.inspect.core.report.Report;
+import org.oneedtech.inspect.test.PrintHelper;
+import org.oneedtech.inspect.util.resource.ResourceType;
+
+public class BitstringStatusListCredentialInspectorTest {
+	private static BitstringStatusListCredentialInspector validator;
+	private static boolean verbose = true;
+
+	@BeforeAll
+	static void setup() {
+		validator = new BitstringStatusListCredentialInspector.Builder()
+				.set(Behavior.TEST_INCLUDE_SUCCESS, true)
+				.set(Behavior.VALIDATOR_FAIL_FAST, true)
+				.build();
+	}
+
+	@Test
+	void testSimpleJsonValid() {
+		assertDoesNotThrow(()->{
+			Report report = validator.run(Samples.BSL.SIMPLE_JSON.asFileResource(ResourceType.JSON));
+			if(verbose) PrintHelper.print(report, true);
+			assertValid(report);
+		});
+	}
+
+}

--- a/inspector-vc/src/test/java/org/oneedtech/inspect/vc/OB30Tests.java
+++ b/inspector-vc/src/test/java/org/oneedtech/inspect/vc/OB30Tests.java
@@ -31,6 +31,7 @@ import org.oneedtech.inspect.vc.probe.IssuanceProbe;
 import org.oneedtech.inspect.vc.probe.IssuerProbe;
 import org.oneedtech.inspect.vc.probe.RevocationListProbe;
 import org.oneedtech.inspect.vc.probe.TypePropertyProbe;
+import org.oneedtech.inspect.vc.status.bitstring.BitstringStatusListProbe;
 
 import com.google.common.collect.Iterables;
 
@@ -456,6 +457,19 @@ public class OB30Tests {
 			Report report = validator.run(Samples.OB30.JSON.SIMPLE_EDDSA_20222_JSON.asFileResource());
 			if(verbose) PrintHelper.print(report, true);
 			assertWarning(report);
+		});
+
+	}
+
+	@Test
+	void testBitstringStatusListRevoked() {
+		assertDoesNotThrow(()->{
+			Report report = validator.run(Samples.BSL.CREDENTIAL_STATUS_REVOKED.asFileResource());
+			if(verbose) PrintHelper.print(report, true);
+			assertInvalid(report);
+			assertErrorCount(report, 0);
+			assertFatalCount(report, 1);
+			assertHasProbeID(report, BitstringStatusListProbe.ID, true);
 		});
 
 	}

--- a/inspector-vc/src/test/java/org/oneedtech/inspect/vc/Samples.java
+++ b/inspector-vc/src/test/java/org/oneedtech/inspect/vc/Samples.java
@@ -127,4 +127,9 @@ public class Samples {
 			public final static Sample SIMPLE_REVOKED_JWT = new Sample("ob20/simple-revoked.jwt", true);
 		}
 	}
+
+	public static final class BSL {
+		public final static Sample SIMPLE_JSON = new Sample("ob30/bit-string-list/testlist", true);
+	}
+
 }

--- a/inspector-vc/src/test/java/org/oneedtech/inspect/vc/Samples.java
+++ b/inspector-vc/src/test/java/org/oneedtech/inspect/vc/Samples.java
@@ -130,6 +130,7 @@ public class Samples {
 
 	public static final class BSL {
 		public final static Sample SIMPLE_JSON = new Sample("ob30/bit-string-list/testlist", true);
+		public final static Sample CREDENTIAL_STATUS_REVOKED = new Sample("ob30/bit-string-list/credential-status-revoked.json", false);
 	}
 
 }

--- a/inspector-vc/src/test/resources/ob30/bit-string-list/credential-status-revoked.json
+++ b/inspector-vc/src/test/resources/ob30/bit-string-list/credential-status-revoked.json
@@ -1,0 +1,62 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json"
+  ],
+  "id": "https://dc.1edtech.org/wellspring2022/wellspring-portal/credential/54418d3f-ec01-4652-800a-861c890a51a1",
+  "type": [
+    "VerifiableCredential",
+    "AchievementCredential"
+  ],
+  "issuer": {
+    "id": "https://1edtech.edu/issuers/565049",
+    "type": [
+      "Profile"
+    ],
+    "name": "1EdTech Testing"
+  },
+  "awardedDate": "2023-05-22T10:21:00Z",
+  "validFrom": "2023-05-23T01:10:41Z",
+  "name": "ob3-credential-status-revoked.json",
+  "description": "This achievement credential is used in ims-inspector OB30Tests.",
+  "credentialSubject": {
+    "id": "did:web:dc.1edtech.org:wellspring2022:wellspring-portal:learner:6896f98f-6b42-4c75-98ec-8befd0dc0b29",
+    "type": [
+      "AchievementSubject"
+    ],
+    "achievement": {
+      "id": "https://dc.1edtech.org/wellspring2022/wellspring-portal/achievement/45badd38-e201-4cf3-927f-be55bc7eb414",
+      "type": [
+        "Achievement"
+      ],
+      "achievementType": "Achievement",
+      "criteria": {
+        "narrative": "Passes tests"
+      },
+      "description": "Test achievement 1",
+      "name": "Achievement 1"
+    },
+    "source": {
+      "id": "did:web:dc.1edtech.org:wellspring2022:wellspring-portal:org:da1e96e9-afcc-4eed-b9a2-2ddf7353214c",
+      "type": [
+        "Profile"
+      ],
+      "name": "1EdTech Testing"
+    }
+  },
+  "credentialStatus": {
+    "id": "https://raw.githubusercontent.com/1EdTech/digital-credentials-public-validator/refs/heads/main/inspector-vc/src/test/resources/ob30/bit-string-list/testlist#23",
+    "type": "BitstringStatusListEntry",
+    "statusPurpose": "revocation",
+    "statusListIndex": "23",
+    "statusListCredential": "https://raw.githubusercontent.com/1EdTech/digital-credentials-public-validator/refs/heads/main/inspector-vc/src/test/resources/ob30/bit-string-list/testlist"
+  },
+  "proof": [{
+    "type": "DataIntegrityProof",
+    "created": "2010-01-01T19:23:24Z",
+    "verificationMethod": "https://1edtech.edu/issuers/565049#z6MkjZRZv3aez3r18pB1RBFJR1kwUVJ5jHt92JmQwXbd5hwi",
+    "cryptosuite": "eddsa-rdfc-2022",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z5xRU4TJpeDQBpa3txAq72FPsfHHhMPHHgm3WVWxkVnd6qoxKysSZfZwkCkuWoxjx4WnkSn425jJ76gkJydXhV5pr"
+  }]
+}

--- a/inspector-vc/src/test/resources/ob30/bit-string-list/testlist
+++ b/inspector-vc/src/test/resources/ob30/bit-string-list/testlist
@@ -1,0 +1,26 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2"
+  ],
+  "id": "https://example.com/credentials/status/3",
+  "type": [
+    "VerifiableCredential",
+    "BitstringStatusListCredential"
+  ],
+  "issuer": "https://1edtech.edu/issuers/565049",
+  "validFrom": "2021-04-05T14:27:40Z",
+  "credentialSubject": {
+    "id": "https://example.com/status/3#list",
+    "type": "BitstringStatusList",
+    "statusPurpose": "revocation",
+    "encodedList": "uH4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA"
+  },
+  "proof": {
+    "type": "DataIntegrityProof",
+    "created": "2010-01-01T19:23:24Z",
+    "verificationMethod": "https://1edtech.edu/issuers/565049#z6MkjZRZv3aez3r18pB1RBFJR1kwUVJ5jHt92JmQwXbd5hwi",
+    "cryptosuite": "eddsa-rdfc-2022",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z3iBGgSL1VpYJ95pDEF1S2To4xR7dNKX1MQqPebyu5wjjK7be71RWjTDfzqdwwsZAjyA8v8D3RPShxt8q6nxvSvAk"
+  }
+}

--- a/inspector-vc/src/test/resources/ob30/bit-string-list/testlist
+++ b/inspector-vc/src/test/resources/ob30/bit-string-list/testlist
@@ -13,14 +13,14 @@
     "id": "https://example.com/status/3#list",
     "type": "BitstringStatusList",
     "statusPurpose": "revocation",
-    "encodedList": "uH4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA"
+    "encodedList": "uH4sIAAAAAAAA_-3BMQEAAAzDoMy_6cnoA9QFAAAAAAAAAAAAAAAAAAAAbD3uPa2cAEAAAA"
   },
-  "proof": {
+  "proof": [{
     "type": "DataIntegrityProof",
     "created": "2010-01-01T19:23:24Z",
     "verificationMethod": "https://1edtech.edu/issuers/565049#z6MkjZRZv3aez3r18pB1RBFJR1kwUVJ5jHt92JmQwXbd5hwi",
     "cryptosuite": "eddsa-rdfc-2022",
     "proofPurpose": "assertionMethod",
-    "proofValue": "z3iBGgSL1VpYJ95pDEF1S2To4xR7dNKX1MQqPebyu5wjjK7be71RWjTDfzqdwwsZAjyA8v8D3RPShxt8q6nxvSvAk"
-  }
+    "proofValue": "z2SkF4nJzMa6wAKgxDdUR1wwZsiYnWi3CtFyRipnMgxUTZKiJvJ1tf5fEtmDFhjkc2JL6XgPTt5SzBCJFSTpBMdDY"
+  }]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.1edtech</groupId>
   <artifactId>vc-public-validator</artifactId>
-  <version>1.1.4</version>
+  <version>1.2.0</version>
   <name>vc-public-validator</name>
   <packaging>pom</packaging>
   <developers>


### PR DESCRIPTION
This pull request includes several changes to the `inspector-vc` project, focusing on updating dependencies, adding new functionality for handling Bitstring Status List Credentials, and refactoring existing code for better readability and maintainability. The most important changes are summarized below:

### Dependency Updates:

* Updated `iron-verifiable-credentials` dependency to version `0.14.0` and added `iron-eddsa-rdfc-2022` dependency.
* Updated `titanium-json-ld` dependency to version `1.4.0`.

### New Functionality:

* Added `BitstringStatusListCredentialInspector` class to handle Bitstring Status List Credentials.
* Added `BitstringStatusListCredential` type to `VerifiableCredential` enum and updated related methods to handle this new type. [[1]](diffhunk://#diff-599c6929ec54be10fbf8c05d6612696df7582b1afeac53ae5fda42f8232316b4R121) [[2]](diffhunk://#diff-599c6929ec54be10fbf8c05d6612696df7582b1afeac53ae5fda42f8232316b4R142-R143)

### Refactoring:

* Replaced deprecated `Multibase` and `Multicodec` classes with `MultibaseDecoder` and `MulticodecDecoder` in `EmbeddedProofProbe`. [[1]](diffhunk://#diff-ef10a6011ba994b7c856f173d0631470270173174f44be6c6ce7077346398b21L23-R25) [[2]](diffhunk://#diff-ef10a6011ba994b7c856f173d0631470270173174f44be6c6ce7077346398b21L160-R160) [[3]](diffhunk://#diff-ef10a6011ba994b7c856f173d0631470270173174f44be6c6ce7077346398b21L177-R177) [[4]](diffhunk://#diff-ef10a6011ba994b7c856f173d0631470270173174f44be6c6ce7077346398b21L214-R215)
* Moved some imports and removed unused imports for better code organization in various files. [[1]](diffhunk://#diff-599c6929ec54be10fbf8c05d6612696df7582b1afeac53ae5fda42f8232316b4L11-L12) [[2]](diffhunk://#diff-e9992deafec856630d65f21df9ff2b6d0abd7efaa8c4dc4a613c661ad6f1b234L7-L8) [[3]](diffhunk://#diff-e9992deafec856630d65f21df9ff2b6d0abd7efaa8c4dc4a613c661ad6f1b234L26-L33)

### Enhancements:

* Enhanced `RevocationListProbe` to support checking credential status for Bitstring Status List Entries. [[1]](diffhunk://#diff-b7b20746d14d529e6fe25af894702a113221f59e57e2cd9f959f2d0338f8ef76R5-R22) [[2]](diffhunk://#diff-b7b20746d14d529e6fe25af894702a113221f59e57e2cd9f959f2d0338f8ef76R39-R96) [[3]](diffhunk://#diff-b7b20746d14d529e6fe25af894702a113221f59e57e2cd9f959f2d0338f8ef76R107-R113)