### PR TITLE
Feature/configurable did resolver url

### DIFF
--- a/inspector-vc-web/pom.xml
+++ b/inspector-vc-web/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
         <artifactId>vc-public-validator</artifactId>
-		<version>1.3.0</version>
+		<version>1.3.1</version>
 	</parent>
 	<artifactId>inspector-vc-web</artifactId>
 	<properties>

--- a/inspector-vc-web/src/main/resources/validators.json
+++ b/inspector-vc-web/src/main/resources/validators.json
@@ -15,6 +15,9 @@
 			"instr": "This validator supports Open Badges 3.0 files.",
 			"spec": "ob",
 			"group": "vc",
+			"initParams": {
+				"DID_RESOLUTION_SERVICE_URL": "http://dev.uniresolver.io/1.0/identifiers/"
+			},
 			"supportsCertification": false,
 			"submissionTypes": ["upload","uri"]
 		},

--- a/inspector-vc/pom.xml
+++ b/inspector-vc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
 		<artifactId>vc-public-validator</artifactId>
-		<version>1.3.0</version>
+		<version>1.3.1</version>
 	</parent>
 	<artifactId>inspector-vc</artifactId>
 	<dependencies>

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/EndorsementInspector.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/EndorsementInspector.java
@@ -2,6 +2,7 @@ package org.oneedtech.inspect.vc;
 
 import static java.lang.Boolean.TRUE;
 import static org.oneedtech.inspect.core.Inspector.Behavior.RESET_CACHES_ON_RUN;
+import static org.oneedtech.inspect.core.Inspector.InjectionKeys.DID_RESOLUTION_SERVICE_URL;
 import static org.oneedtech.inspect.core.probe.RunContext.Key.GENERATED_OBJECT_BUILDER;
 import static org.oneedtech.inspect.core.probe.RunContext.Key.JACKSON_OBJECTMAPPER;
 import static org.oneedtech.inspect.core.probe.RunContext.Key.JSONPATH_EVALUATOR;
@@ -64,7 +65,8 @@ public class EndorsementInspector extends VCInspector implements SubInspector {
 	protected EndorsementInspector(EndorsementInspector.Builder builder) {
 		super(builder);
 		this.userProbes = ImmutableList.copyOf(builder.probes);
-		this.didResolutionUrl = builder.didResolutionUrl;
+		Optional<Object> didResolutionServiceUrl = builder.getInjected(DID_RESOLUTION_SERVICE_URL);
+		this.didResolutionUrl = didResolutionServiceUrl.isPresent() ? didResolutionServiceUrl.get().toString(): null;
 	}
 
 	@Override
@@ -247,17 +249,10 @@ public class EndorsementInspector extends VCInspector implements SubInspector {
 	}
 
 	public static class Builder extends VCInspector.Builder<EndorsementInspector.Builder> {
-		String didResolutionUrl = "http://dev.uniresolver.io/1.0/identifiers/"; // default to dev's environment
-
 		@SuppressWarnings("unchecked")
 		@Override
 		public EndorsementInspector build() {
 			return new EndorsementInspector(this);
-		}
-
-		public EndorsementInspector.Builder didResolutionUrl(String didResolutionUrl) {
-			this.didResolutionUrl = didResolutionUrl;
-			return this;
 		}
 	}
 

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/OB30Inspector.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/OB30Inspector.java
@@ -2,6 +2,7 @@ package org.oneedtech.inspect.vc;
 
 import static java.lang.Boolean.TRUE;
 import static org.oneedtech.inspect.core.Inspector.Behavior.RESET_CACHES_ON_RUN;
+import static org.oneedtech.inspect.core.Inspector.InjectionKeys.DID_RESOLUTION_SERVICE_URL;
 import static org.oneedtech.inspect.core.report.ReportUtil.onProbeException;
 import static org.oneedtech.inspect.util.code.Defensives.checkNotNull;
 import static org.oneedtech.inspect.util.json.ObjectMapperCache.Config.DEFAULT;
@@ -69,7 +70,8 @@ public class OB30Inspector extends VCInspector implements SubInspector {
 	protected OB30Inspector(OB30Inspector.Builder builder) {
 		super(builder);
 		this.userProbes = ImmutableList.copyOf(builder.probes);
-		this.didResolutionUrl = builder.didResolutionUrl;
+		Optional<Object> didResolutionServiceUrl = builder.getInjected(DID_RESOLUTION_SERVICE_URL);
+		this.didResolutionUrl = didResolutionServiceUrl.isPresent() ? didResolutionServiceUrl.get().toString(): null;
 	}
 
 	//https://docs.google.com/document/d/1_imUl2K-5tMib0AUxwA9CWb0Ap1b3qif0sXydih68J0/edit#
@@ -230,7 +232,7 @@ public class OB30Inspector extends VCInspector implements SubInspector {
 			}
 
 			//embedded endorsements
-			EndorsementInspector endorsementInspector = new EndorsementInspector.Builder().didResolutionUrl(this.didResolutionUrl).build();
+			EndorsementInspector endorsementInspector = new EndorsementInspector.Builder().inject(DID_RESOLUTION_SERVICE_URL, didResolutionUrl).build();
 
 			List<JsonNode> endorsements = asNodeList(ob.getJson(), "$..endorsement", jsonPath);
 			for(JsonNode node : endorsements) {
@@ -258,19 +260,12 @@ public class OB30Inspector extends VCInspector implements SubInspector {
 	}
 
 	public static class Builder extends VCInspector.Builder<OB30Inspector.Builder> {
-		String didResolutionUrl = "http://dev.uniresolver.io/1.0/identifiers/"; // default to dev's environment
-
 		@SuppressWarnings("unchecked")
 		@Override
 		public OB30Inspector build() {
 			set(Specification.OB30);
 			set(ResourceType.OPENBADGE);
 			return new OB30Inspector(this);
-		}
-
-		public OB30Inspector.Builder didResolutionUrl(String didResolutionUrl) {
-			this.didResolutionUrl = didResolutionUrl;
-			return this;
 		}
 	}
 }

--- a/inspector-vc/src/test/java/org/oneedtech/inspect/vc/OB30Tests.java
+++ b/inspector-vc/src/test/java/org/oneedtech/inspect/vc/OB30Tests.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.oneedtech.inspect.core.Inspector;
 import org.oneedtech.inspect.core.Inspector.Behavior;
 import org.oneedtech.inspect.core.probe.GeneratedObject;
 import org.oneedtech.inspect.core.probe.json.JsonSchemaProbe;
@@ -44,6 +45,7 @@ public class OB30Tests {
 		validator = new OB30Inspector.Builder()
 				.set(Behavior.TEST_INCLUDE_SUCCESS, true)
 				.set(Behavior.VALIDATOR_FAIL_FAST, true)
+				.inject(Inspector.InjectionKeys.DID_RESOLUTION_SERVICE_URL, "http://dev.uniresolver.io/1.0/identifiers/")
 				.build();
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <java.version>17</java.version>
     <log4j.version>2.17.2</log4j.version>
     <skipTests>false</skipTests>
-    <public.core.version>1.1.2</public.core.version>
+    <public.core.version>1.1.4</public.core.version>
   </properties>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.1edtech</groupId>
   <artifactId>vc-public-validator</artifactId>
-  <version>1.3.0</version>
+  <version>1.3.1</version>
   <name>vc-public-validator</name>
   <packaging>pom</packaging>
   <developers>


### PR DESCRIPTION
This pull request includes several updates to the `inspector-vc` project, focusing on version upgrades and the introduction of a new injection key for the DID resolution service URL. The most important changes involve modifying the `EndorsementInspector` and `OB30Inspector` classes to use the new injection key, as well as updating the project dependencies.

### Version Upgrades:
* Updated the version of `vc-public-validator` from `1.3.0` to `1.3.1` in `pom.xml` files. [[1]](diffhunk://#diff-fc5de3c5d9d5ffbbeaa45585389b5da045bc73a03516ebf65c926832239f4429L9-R9) [[2]](diffhunk://#diff-bdb9b1be994556dea665c6690e2b82840b5918025609833003c68d3a17c0e2c1L8-R8) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L10-R10)
* Updated the `public.core.version` from `1.1.2` to `1.1.4` in the root `pom.xml`.

### Configuration Changes:
* Added `initParams` for the DID resolution service URL in `validators.json`.

### Codebase Modifications:
* Modified `EndorsementInspector` and `OB30Inspector` classes to use the new injection key `DID_RESOLUTION_SERVICE_URL` instead of hardcoding the URL. [[1]](diffhunk://#diff-e9c9a1546690fed16566346bd9d3ad63edcbfdacebb1c4e564af2708488302adR5) [[2]](diffhunk://#diff-e9c9a1546690fed16566346bd9d3ad63edcbfdacebb1c4e564af2708488302adL67-R69) [[3]](diffhunk://#diff-e9c9a1546690fed16566346bd9d3ad63edcbfdacebb1c4e564af2708488302adL250-L261) [[4]](diffhunk://#diff-246a0ba1452661936f8a3b0ce1d4076e914e2b540c0b16783ccbfbd38b5de0d6R5) [[5]](diffhunk://#diff-246a0ba1452661936f8a3b0ce1d4076e914e2b540c0b16783ccbfbd38b5de0d6L72-R74) [[6]](diffhunk://#diff-246a0ba1452661936f8a3b0ce1d4076e914e2b540c0b16783ccbfbd38b5de0d6L233-R235) [[7]](diffhunk://#diff-246a0ba1452661936f8a3b0ce1d4076e914e2b540c0b16783ccbfbd38b5de0d6L261-L274)

### Test Updates:
* Injected the DID resolution service URL in `OB30Tests` setup method. [[1]](diffhunk://#diff-7a3b4882e3d87c7cacf496d09eed0dac0a1369369da8923f6c98d21ae70c531cR18) [[2]](diffhunk://#diff-7a3b4882e3d87c7cacf496d09eed0dac0a1369369da8923f6c98d21ae70c531cR48)