### PR TITLE
Add ECDSA support and fixed DID resolution for hosted public keys

### DIFF
--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/did/SimpleDidResolver.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/did/SimpleDidResolver.java
@@ -73,8 +73,8 @@ public class SimpleDidResolver implements DidResolver {
       }
 
       // 4. If no path has been specified in the URL, append /.well-known.
-      if (uri.getPath() == null) {
-        uri = uri.resolve("/well-known");
+      if (uri.getPath() == null || uri.getPath().isEmpty()) {
+        uri = uri.resolve("/.well-known");
       }
 
       // 5. Append /did.json to complete the URL.
@@ -175,11 +175,13 @@ public class SimpleDidResolver implements DidResolver {
     JsonObject verificationMethod = verificationMethodMaybe.get().asJsonObject();
     // assuming a Ed25519VerificationKey2020 document
     builder
-        .controller(verificationMethod.getString("controller"))
-        .publicKeyMultibase(verificationMethod.getString("publicKeyMultibase"));
+            .controller(verificationMethod.getString("controller"));
     // check JWK
     if (verificationMethod.containsKey("publicKeyJwk"))
-        builder.publicKeyJwk(verificationMethod.getJsonObject("publicKeyJwk").toString());
+      builder.publicKeyJwk(verificationMethod.getJsonObject("publicKeyJwk").toString());
+    // check Multibase
+    if (verificationMethod.containsKey("publicKeyMultibase"))
+      builder.publicKeyMultibase(verificationMethod.getString("publicKeyMultibase"));
 
   }
 }


### PR DESCRIPTION
Introduced support for ECDSA (ES256) signature verification and improved DID resolution process for better compatibility with web-hosted DID documents.

Changes include:

**ExternalProofProbe.java**
  - Added support for ECDSA (ES256) in addition to RSA (RS256) when validating JWT signatures.
  - Replaced usage of the default _ConfigurableDocumentLoader.DOCUMENT_LOADER_ with _new CachingDocumentLoader()_ to ensure _enableHttp_, _enableHttps_, and _enableFile_ flags are correctly enabled by default.

**SimpleDidResolver.java**
  - Fixed the **_.well-known_** DID resolution path by correcting the variable assignment (from _/well-known_ to _./well-known_) as specified in the VC Data Model spec.
  - Replaced _**uri.getPath() == null**_ with a check for an empty string (_.isEmpty()_), since _getPath()_ never returns _null_.
  - Modified the logic when extracting the public key from a DID document:
    - Previously, _publicKeyMultibase_ was **required** and would throw if missing.
    - Now, both _publicKeyJwk_ and _publicKeyMultibase_ are handled conditionally:
      - If **_publicKeyJwk_** is present, it is parsed and used.
      - If **_publicKeyMultibase_** is present, it is used instead.
    - This provides compatibility with DID documents using either key representation format, as permitted by the spec.