### PR TITLE
Hotfix/deps

### DIFF
--- a/inspector-clr/pom.xml
+++ b/inspector-clr/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
 		<artifactId>vc-public-validator</artifactId>
-		<version>1.3.6</version>
+		<version>1.3.7</version>
 	</parent>
 	<artifactId>inspector-clr</artifactId>
 	<dependencies>

--- a/inspector-vc-web/pom.xml
+++ b/inspector-vc-web/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
         <artifactId>vc-public-validator</artifactId>
-		<version>1.3.6</version>
+		<version>1.3.7</version>
 	</parent>
 	<artifactId>inspector-vc-web</artifactId>
 	<properties>

--- a/inspector-vc/pom.xml
+++ b/inspector-vc/pom.xml
@@ -37,10 +37,22 @@
 		</dependency>
 
 		<!-- https://github.com/filip26/iron-eddsa-rdfc-2022 -->
-		<dependency>
+		<!-- <dependency>
 			<groupId>com.apicatalog</groupId>
 			<artifactId>iron-eddsa-rdfc-2022</artifactId>
 			<version>0.14.0</version>
+		</dependency> -->
+		<!-- https://github.com/filip26/copper-multibase -->
+		<dependency>
+			<groupId>com.apicatalog</groupId>
+    		<artifactId>copper-multibase</artifactId>
+    		<version>1.0.0</version>
+		</dependency>
+		<!-- https://github.com/filip26/copper-multicodec -->
+		<dependency>
+			<groupId>com.apicatalog</groupId>
+    		<artifactId>copper-multicodec</artifactId>
+    		<version>1.1.0</version>
 		</dependency>
 
 		<!-- universal did resolver client -->

--- a/inspector-vc/pom.xml
+++ b/inspector-vc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
 		<artifactId>vc-public-validator</artifactId>
-		<version>1.3.6</version>
+		<version>1.3.7</version>
 	</parent>
 	<artifactId>inspector-vc</artifactId>
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.1edtech</groupId>
   <artifactId>vc-public-validator</artifactId>
-  <version>1.3.6</version>
+  <version>1.3.7</version>
   <name>vc-public-validator</name>
   <packaging>pom</packaging>
   <developers>


### PR DESCRIPTION
This pull request updates the version of the parent dependency across multiple `pom.xml` files and makes adjustments to dependencies in the `inspector-vc/pom.xml` file to include new libraries while commenting out an older one.

### Dependency Version Updates:
* Updated the parent dependency `vc-public-validator` from version `1.3.6` to `1.3.7` in the following files:
  - `inspector-clr/pom.xml`
  - `inspector-vc-web/pom.xml`
  - `inspector-vc/pom.xml`
  - `pom.xml`

### Dependency Adjustments:
* In `inspector-vc/pom.xml`:
  - Commented out the dependency for `iron-eddsa-rdfc-2022` and added two new dependencies:
    - `copper-multibase` version `1.0.0`
    - `copper-multicodec` version `1.1.0`