### PR TITLE
Rename `JsonLDCompactionProve` to `JsonLDCompactionProbe`

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Environment-dependent path to Maven home directory
+/mavenHomeManager.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <module name="inspector-vc-web" />
+        <module name="inspector-vc" />
+        <module name="inspector-clr" />
+      </profile>
+    </annotationProcessing>
+  </component>
+</project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/inspector-clr/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/inspector-clr/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/inspector-vc-web/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/inspector-vc-web/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/inspector-vc/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/inspector-vc/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Central Repository" />
+      <option name="url" value="https://repo.maven.apache.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="1edtech-public-snapshots" />
+      <option name="name" value="1EdTech Public Snapshot" />
+      <option name="url" value="https://nexus.1edtech.net/repository/1edtech-public-snapshot/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="danubetech-public" />
+      <option name="name" value="Danubetech Public" />
+      <option name="url" value="https://repo.danubetech.com/repository/maven-public" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="1edtech-public-release" />
+      <option name="name" value="1EdTech Public Release" />
+      <option name="url" value="https://nexus.1edtech.net/repository/1edtech-public-release/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="temurin-21" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/OB20Inspector.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/OB20Inspector.java
@@ -33,7 +33,7 @@ import org.oneedtech.inspect.vc.Credential.CredentialEnum;
 import org.oneedtech.inspect.vc.jsonld.JsonLdGeneratedObject;
 import org.oneedtech.inspect.vc.jsonld.probe.ExtensionProbe;
 import org.oneedtech.inspect.vc.jsonld.probe.GraphFetcherProbe;
-import org.oneedtech.inspect.vc.jsonld.probe.JsonLDCompactionProve;
+import org.oneedtech.inspect.vc.jsonld.probe.JsonLDCompactionProbe;
 import org.oneedtech.inspect.vc.jsonld.probe.JsonLDValidationProbe;
 import org.oneedtech.inspect.vc.payload.PngParser;
 import org.oneedtech.inspect.vc.payload.SvgParser;
@@ -116,11 +116,11 @@ public class OB20Inspector extends VCInspector {
 			}
 
 			// let's compact
-			accumulator.add(new JsonLDCompactionProve(assertion.getCredentialType().getContextUris().get(0)).run(assertion, ctx));
+			accumulator.add(new JsonLDCompactionProbe(assertion.getCredentialType().getContextUris().get(0)).run(assertion, ctx));
 			if(broken(accumulator, true)) return abort(ctx, accumulator, probeCount);
 
 			// validate JSON LD
-			JsonLdGeneratedObject jsonLdGeneratedObject = ctx.getGeneratedObject(JsonLDCompactionProve.getId(assertion));
+			JsonLdGeneratedObject jsonLdGeneratedObject = ctx.getGeneratedObject(JsonLDCompactionProbe.getId(assertion));
 			accumulator.add(new JsonLDValidationProbe(jsonLdGeneratedObject).run(assertion, ctx));
 			if(broken(accumulator, true)) return abort(ctx, accumulator, probeCount);
 
@@ -205,7 +205,7 @@ public class OB20Inspector extends VCInspector {
 				probeCount++;
 				// get endorsement json from context
 				UriResource uriResource = uriResourceFactory.of(node.asText());
-				JsonLdGeneratedObject resolved = (JsonLdGeneratedObject) ctx.getGeneratedObject(JsonLDCompactionProve.getId(uriResource));
+				JsonLdGeneratedObject resolved = (JsonLdGeneratedObject) ctx.getGeneratedObject(JsonLDCompactionProbe.getId(uriResource));
 				if (resolved == null) {
 					throw new IllegalArgumentException("endorsement " + node.toString() + " not found in graph");
 				}

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/jsonld/probe/GraphFetcherProbe.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/jsonld/probe/GraphFetcherProbe.java
@@ -82,7 +82,7 @@ public class GraphFetcherProbe extends Probe<JsonNode> {
                         // add a new node to the graph
                         UUID newId = UUID.randomUUID();
                         JsonNode merged = createNewJson(ctx, "{\"id\": \"_:" + newId + "\"}");
-                        ctx.addGeneratedObject(new JsonLdGeneratedObject(JsonLDCompactionProve.getId(newId.toString()), merged.toString()));
+                        ctx.addGeneratedObject(new JsonLdGeneratedObject(JsonLDCompactionProbe.getId(newId.toString()), merged.toString()));
 
                         // update existing node with new id
                         updateNode(validation, idNode, ctx);
@@ -97,7 +97,7 @@ public class GraphFetcherProbe extends Probe<JsonNode> {
 
                         // add a new node to the graph
                         JsonNode merged = createNewJson(ctx, node);
-                        ctx.addGeneratedObject(new JsonLdGeneratedObject(JsonLDCompactionProve.getId(idNode.asText().strip()), merged.toString()));
+                        ctx.addGeneratedObject(new JsonLdGeneratedObject(JsonLDCompactionProbe.getId(idNode.asText().strip()), merged.toString()));
 
                         // update existing node with new id
                         updateNode(validation, idNode, ctx);
@@ -129,7 +129,7 @@ public class GraphFetcherProbe extends Probe<JsonNode> {
             throws URISyntaxException, Exception, JsonProcessingException, JsonMappingException {
         System.out.println("fetchNode " + idNode.asText().strip());
         UriResource uriResource = ((UriResourceFactory) ctx.get(Key.URI_RESOURCE_FACTORY)).of(idNode.asText().strip());
-        JsonLdGeneratedObject resolved = (JsonLdGeneratedObject) ctx.getGeneratedObject(JsonLDCompactionProve.getId(uriResource));
+        JsonLdGeneratedObject resolved = (JsonLdGeneratedObject) ctx.getGeneratedObject(JsonLDCompactionProbe.getId(uriResource));
         if (resolved == null) {
             System.out.println("parsing and loading " + idNode.asText().strip());
             result = new ReportItems(List.of(result, new CredentialParseProbe().run(uriResource, ctx)));
@@ -137,9 +137,9 @@ public class GraphFetcherProbe extends Probe<JsonNode> {
                 Assertion fetchedAssertion = (Assertion) ctx.getGeneratedObject(uriResource.getID());
 
                 // compact ld
-                result = new ReportItems(List.of(result, new JsonLDCompactionProve(fetchedAssertion.getCredentialType().getContextUris().get(0)).run(fetchedAssertion, ctx)));
+                result = new ReportItems(List.of(result, new JsonLDCompactionProbe(fetchedAssertion.getCredentialType().getContextUris().get(0)).run(fetchedAssertion, ctx)));
                 if (!result.contains(Outcome.FATAL, Outcome.EXCEPTION)) {
-                    JsonLdGeneratedObject fetched = (JsonLdGeneratedObject) ctx.getGeneratedObject(JsonLDCompactionProve.getId(fetchedAssertion));
+                    JsonLdGeneratedObject fetched = (JsonLdGeneratedObject) ctx.getGeneratedObject(JsonLDCompactionProbe.getId(fetchedAssertion));
                     JsonNode fetchedNode = ((ObjectMapper) ctx.get(Key.JACKSON_OBJECTMAPPER)).readTree(fetched.getJson());
 
                     // recursive call
@@ -166,7 +166,7 @@ public class GraphFetcherProbe extends Probe<JsonNode> {
     }
 
     private void updateNode(Validation validation, JsonNode idNode, RunContext ctx) throws IOException {
-        JsonLdGeneratedObject jsonLdGeneratedObject = ctx.getGeneratedObject(JsonLDCompactionProve.getId(assertion));
+        JsonLdGeneratedObject jsonLdGeneratedObject = ctx.getGeneratedObject(JsonLDCompactionProbe.getId(assertion));
         JsonNode merged = createNewJson(ctx, jsonLdGeneratedObject.getJson(), "{\"" + validation.getName() + "\": \"" + idNode.asText().strip() + "\"}");
         jsonLdGeneratedObject.setJson(merged.toString());
 

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/jsonld/probe/JsonLDCompactionProbe.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/jsonld/probe/JsonLDCompactionProbe.java
@@ -22,10 +22,10 @@ import jakarta.json.JsonObject;
  * Maps to "JSONLD_COMPACT_DATA" task in python implementation
  * @author xaracil
  */
-public class JsonLDCompactionProve extends Probe<Credential> {
+public class JsonLDCompactionProbe extends Probe<Credential> {
     private final String context;
 
-    public JsonLDCompactionProve(String context) {
+    public JsonLDCompactionProbe(String context) {
         super(ID);
         this.context = context;
     }
@@ -65,5 +65,5 @@ public class JsonLDCompactionProve extends Probe<Credential> {
       return "json-ld-compact:" + id;
     }
 
-	public static final String ID = JsonLDCompactionProve.class.getSimpleName();
+	public static final String ID = JsonLDCompactionProbe.class.getSimpleName();
 }

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/AssertionRevocationListProbe.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/AssertionRevocationListProbe.java
@@ -14,7 +14,7 @@ import org.oneedtech.inspect.core.probe.RunContext.Key;
 import org.oneedtech.inspect.core.report.ReportItems;
 import org.oneedtech.inspect.util.resource.UriResource;
 import org.oneedtech.inspect.vc.jsonld.JsonLdGeneratedObject;
-import org.oneedtech.inspect.vc.jsonld.probe.JsonLDCompactionProve;
+import org.oneedtech.inspect.vc.jsonld.probe.JsonLDCompactionProbe;
 import org.oneedtech.inspect.vc.resource.UriResourceFactory;
 import org.oneedtech.inspect.vc.util.CachingDocumentLoader;
 import org.oneedtech.inspect.vc.util.JsonNodeUtil;
@@ -47,7 +47,7 @@ public class AssertionRevocationListProbe extends Probe<JsonLdGeneratedObject> {
         // get badge
         UriResource badgeUriResource = uriResourceFactory.of(getBadgeClaimId(jsonNode));
         JsonLdGeneratedObject badgeObject = (JsonLdGeneratedObject) ctx.getGeneratedObject(
-            JsonLDCompactionProve.getId(badgeUriResource));
+            JsonLDCompactionProbe.getId(badgeUriResource));
 
         // get issuer from badge
         JsonNode badgeNode = ((ObjectMapper) ctx.get(Key.JACKSON_OBJECTMAPPER))
@@ -55,7 +55,7 @@ public class AssertionRevocationListProbe extends Probe<JsonLdGeneratedObject> {
 
         UriResource issuerUriResource = uriResourceFactory.of(badgeNode.get("issuer").asText().strip());
         JsonLdGeneratedObject issuerObject = (JsonLdGeneratedObject) ctx.getGeneratedObject(
-            JsonLDCompactionProve.getId(issuerUriResource));
+            JsonLDCompactionProbe.getId(issuerUriResource));
         JsonNode issuerNode = ((ObjectMapper) ctx.get(Key.JACKSON_OBJECTMAPPER))
             .readTree(issuerObject.getJson());
 
@@ -67,7 +67,7 @@ public class AssertionRevocationListProbe extends Probe<JsonLdGeneratedObject> {
 
         UriResource revocationListUriResource = uriResourceFactory.of(revocationListIdNode.asText().strip());
         JsonLdGeneratedObject revocationListObject = (JsonLdGeneratedObject) ctx.getGeneratedObject(
-            JsonLDCompactionProve.getId(revocationListUriResource));
+            JsonLDCompactionProbe.getId(revocationListUriResource));
         JsonNode revocationListNode = ((ObjectMapper) ctx.get(Key.JACKSON_OBJECTMAPPER))
             .readTree(revocationListObject.getJson());
 

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/VerificationDependenciesProbe.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/VerificationDependenciesProbe.java
@@ -12,7 +12,7 @@ import org.oneedtech.inspect.core.probe.RunContext.Key;
 import org.oneedtech.inspect.core.report.ReportItems;
 import org.oneedtech.inspect.util.resource.UriResource;
 import org.oneedtech.inspect.vc.jsonld.JsonLdGeneratedObject;
-import org.oneedtech.inspect.vc.jsonld.probe.JsonLDCompactionProve;
+import org.oneedtech.inspect.vc.jsonld.probe.JsonLDCompactionProbe;
 import org.oneedtech.inspect.vc.resource.UriResourceFactory;
 import org.oneedtech.inspect.vc.util.JsonNodeUtil;
 
@@ -52,7 +52,7 @@ public class VerificationDependenciesProbe extends Probe<JsonLdGeneratedObject> 
             // get verification from graph
             UriResource verificationUriResource = uriResourceFactory.of(verificationNode.asText().strip());
             JsonLdGeneratedObject verificationObject = (JsonLdGeneratedObject) ctx.getGeneratedObject(
-                JsonLDCompactionProve.getId(verificationUriResource));
+                JsonLDCompactionProbe.getId(verificationUriResource));
             JsonNode verificationRootNode = ((ObjectMapper) ctx.get(Key.JACKSON_OBJECTMAPPER))
                 .readTree(verificationObject.getJson());
             type = verificationRootNode.get("type").asText().strip();
@@ -64,7 +64,7 @@ public class VerificationDependenciesProbe extends Probe<JsonLdGeneratedObject> 
             // get badge
             UriResource badgeUriResource = uriResourceFactory.of(getBadgeClaimId(jsonNode));
             JsonLdGeneratedObject badgeObject = (JsonLdGeneratedObject) ctx.getGeneratedObject(
-                JsonLDCompactionProve.getId(badgeUriResource));
+                JsonLDCompactionProbe.getId(badgeUriResource));
             JsonNode badgeNode = ((ObjectMapper) ctx.get(Key.JACKSON_OBJECTMAPPER))
                 .readTree(badgeObject.getJson());
 
@@ -72,7 +72,7 @@ public class VerificationDependenciesProbe extends Probe<JsonLdGeneratedObject> 
             UriResource issuerUriResource = uriResourceFactory.of(badgeNode.get("issuer").asText().strip());
 
             JsonLdGeneratedObject issuerObject = (JsonLdGeneratedObject) ctx.getGeneratedObject(
-                JsonLDCompactionProve.getId(issuerUriResource));
+                JsonLDCompactionProbe.getId(issuerUriResource));
             JsonNode issuerNode = ((ObjectMapper) ctx.get(Key.JACKSON_OBJECTMAPPER))
                 .readTree(issuerObject.getJson());
 
@@ -83,7 +83,7 @@ public class VerificationDependenciesProbe extends Probe<JsonLdGeneratedObject> 
                 if (verificationPolicy.isTextual()) {
                     // get verification node
                     JsonLdGeneratedObject verificationPolicyObject = (JsonLdGeneratedObject) ctx.getGeneratedObject(
-                        JsonLDCompactionProve.getId(verificationPolicy.asText().strip()));
+                        JsonLDCompactionProbe.getId(verificationPolicy.asText().strip()));
                         verificationPolicy = ((ObjectMapper) ctx.get(Key.JACKSON_OBJECTMAPPER))
                             .readTree(verificationPolicyObject.getJson());
                 }

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/VerificationJWTProbe.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/VerificationJWTProbe.java
@@ -14,7 +14,7 @@ import org.oneedtech.inspect.core.probe.RunContext.Key;
 import org.oneedtech.inspect.core.report.ReportItems;
 import org.oneedtech.inspect.util.resource.UriResource;
 import org.oneedtech.inspect.vc.jsonld.JsonLdGeneratedObject;
-import org.oneedtech.inspect.vc.jsonld.probe.JsonLDCompactionProve;
+import org.oneedtech.inspect.vc.jsonld.probe.JsonLDCompactionProbe;
 import org.oneedtech.inspect.vc.resource.UriResourceFactory;
 import org.oneedtech.inspect.vc.util.CachingDocumentLoader;
 import org.oneedtech.inspect.vc.util.JsonNodeUtil;
@@ -50,7 +50,7 @@ public class VerificationJWTProbe extends Probe<JsonLdGeneratedObject> {
         // get badge from assertion
         UriResource badgeUriResource = uriResourceFactory.of(assertionNode.get("badge").asText().strip());
         JsonLdGeneratedObject badgeObject = (JsonLdGeneratedObject) ctx.getGeneratedObject(
-            JsonLDCompactionProve.getId(badgeUriResource));
+            JsonLDCompactionProbe.getId(badgeUriResource));
         JsonNode badgeNode = ((ObjectMapper) ctx.get(Key.JACKSON_OBJECTMAPPER))
             .readTree(badgeObject.getJson());
 
@@ -58,7 +58,7 @@ public class VerificationJWTProbe extends Probe<JsonLdGeneratedObject> {
         UriResource issuerUriResource = uriResourceFactory.of(badgeNode.get("issuer").asText().strip());
 
         JsonLdGeneratedObject issuerObject = (JsonLdGeneratedObject) ctx.getGeneratedObject(
-            JsonLDCompactionProve.getId(issuerUriResource));
+            JsonLDCompactionProbe.getId(issuerUriResource));
         JsonNode issuerNode = ((ObjectMapper) ctx.get(Key.JACKSON_OBJECTMAPPER))
             .readTree(issuerObject.getJson());
 
@@ -75,7 +75,7 @@ public class VerificationJWTProbe extends Probe<JsonLdGeneratedObject> {
         // get creator from id
         UriResource creatorUriResource = uriResourceFactory.of(creatorId);
         JsonLdGeneratedObject creatorObject = (JsonLdGeneratedObject) ctx.getGeneratedObject(
-            JsonLDCompactionProve.getId(creatorUriResource));
+            JsonLDCompactionProbe.getId(creatorUriResource));
         JsonNode creatorNode = ((ObjectMapper) ctx.get(Key.JACKSON_OBJECTMAPPER))
             .readTree(creatorObject.getJson());
 

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/VerificationRecipientProbe.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/VerificationRecipientProbe.java
@@ -12,7 +12,7 @@ import org.oneedtech.inspect.core.probe.RunContext.Key;
 import org.oneedtech.inspect.core.report.ReportItems;
 import org.oneedtech.inspect.vc.Assertion;
 import org.oneedtech.inspect.vc.jsonld.JsonLdGeneratedObject;
-import org.oneedtech.inspect.vc.jsonld.probe.JsonLDCompactionProve;
+import org.oneedtech.inspect.vc.jsonld.probe.JsonLDCompactionProbe;
 import org.oneedtech.inspect.vc.util.JsonNodeUtil;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -36,7 +36,7 @@ public class VerificationRecipientProbe extends Probe<Assertion> {
         ReportItems warnings = new ReportItems();
         JsonNode recipientNode = assertion.getJson().get("recipient");
 
-        JsonLdGeneratedObject profileObject = (JsonLdGeneratedObject) ctx.getGeneratedObject(JsonLDCompactionProve.getId(profileId));
+        JsonLdGeneratedObject profileObject = (JsonLdGeneratedObject) ctx.getGeneratedObject(JsonLDCompactionProbe.getId(profileId));
         JsonNode profileNode = ((ObjectMapper) ctx.get(Key.JACKSON_OBJECTMAPPER)).readTree(profileObject.getJson());
 
         String type = recipientNode.get("type").asText().strip();

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/validation/ValidationPropertyProbe.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/validation/ValidationPropertyProbe.java
@@ -18,7 +18,7 @@ import org.oneedtech.inspect.util.resource.UriResource;
 import org.oneedtech.inspect.vc.Assertion.ValueType;
 import org.oneedtech.inspect.vc.Validation;
 import org.oneedtech.inspect.vc.jsonld.JsonLdGeneratedObject;
-import org.oneedtech.inspect.vc.jsonld.probe.JsonLDCompactionProve;
+import org.oneedtech.inspect.vc.jsonld.probe.JsonLDCompactionProbe;
 import org.oneedtech.inspect.vc.probe.PropertyProbe;
 import org.oneedtech.inspect.vc.resource.UriResourceFactory;
 import org.oneedtech.inspect.vc.util.JsonNodeUtil;
@@ -123,7 +123,7 @@ public class ValidationPropertyProbe extends PropertyProbe {
 
                     // get node from context
                     UriResource uriResource = ((UriResourceFactory) ctx.get(Key.URI_RESOURCE_FACTORY)).of(childNode.asText().strip());
-                    JsonLdGeneratedObject resolved = (JsonLdGeneratedObject) ctx.getGeneratedObject(JsonLDCompactionProve.getId(uriResource));
+                    JsonLdGeneratedObject resolved = (JsonLdGeneratedObject) ctx.getGeneratedObject(JsonLDCompactionProbe.getId(uriResource));
                     if (resolved == null) {
                         if (validation.isAllowRemoteUrl() && URL.getValidationFunction().apply(childNode)) {
                             continue;


### PR DESCRIPTION
## Description  
This PR renames the misnamed class `JsonLDCompactionProve` to `JsonLDCompactionProbe` to align with the `*Probe` naming convention in the `org.oneedtech.inspect.vc.jsonld.probe` package.

### Related Issue  
- Fixes #29

### Changes  
- **Renamed file**:  
  - `inspector-vc/src/main/java/org/oneedtech/inspect/vc/jsonld/probe/JsonLDCompactionProve.java` → `JsonLDCompactionProbe.java`
- **Updated class declaration**:  
  ```diff
  - public class JsonLDCompactionProve extends Probe<Credential> {
  + public class JsonLDCompactionProbe extends Probe<Credential> {
  ```
- **Adjusted constructor and method names** if necessary (none required in this case).  
- **Updated import references** in any classes or tests (none discovered).

## Verification  
- Compiled the project to ensure no reference errors.
