### PR TITLE
OB 2.0 Legacy PNG support

### DIFF
--- a/inspector-clr/pom.xml
+++ b/inspector-clr/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
 		<artifactId>vc-public-validator</artifactId>
-		<version>1.4.1</version>
+		<version>1.4.2</version>
 	</parent>
 	<artifactId>inspector-clr</artifactId>
 	<dependencies>

--- a/inspector-vc-web/pom.xml
+++ b/inspector-vc-web/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
         <artifactId>vc-public-validator</artifactId>
-		<version>1.4.1</version>
+		<version>1.4.2</version>
 	</parent>
 	<artifactId>inspector-vc-web</artifactId>
 	<properties>

--- a/inspector-vc/pom.xml
+++ b/inspector-vc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
 		<artifactId>vc-public-validator</artifactId>
-		<version>1.4.1</version>
+		<version>1.4.2</version>
 	</parent>
 	<artifactId>inspector-vc</artifactId>
 	<dependencies>

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/payload/PayloadParser.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/payload/PayloadParser.java
@@ -2,6 +2,7 @@ package org.oneedtech.inspect.vc.payload;
 
 import static com.apicatalog.jsonld.StringUtils.isBlank;
 
+import java.net.URI;
 import java.util.Base64;
 import java.util.Base64.Decoder;
 import java.util.List;
@@ -10,6 +11,7 @@ import org.oneedtech.inspect.core.probe.RunContext;
 import org.oneedtech.inspect.core.probe.RunContext.Key;
 import org.oneedtech.inspect.util.resource.Resource;
 import org.oneedtech.inspect.util.resource.ResourceType;
+import org.oneedtech.inspect.util.resource.UriResource;
 import org.oneedtech.inspect.vc.Credential;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -62,6 +64,25 @@ public abstract class PayloadParser {
 		}
 
 		return vcNode;
+	}
+
+	/**
+	 * Parses a JSON payload from the specified URI and returns it as a {@link JsonNode}.
+	 *
+	 * <p>This method creates a {@link Resource} of type JSON from the given URI,
+	 * uses a {@link PayloadParserFactory} to obtain a parser, and parses the resource
+	 * within the provided {@link RunContext}. The resulting {@link Credential} object
+	 * is then used to retrieve the JSON representation.</p>
+	 *
+	 * @param uri the URI pointing to the JSON resource to be parsed
+	 * @param context the execution context for the parsing operation
+	 * @return the parsed JSON payload as a {@link JsonNode}
+	 * @throws Exception if an error occurs during parsing or resource retrieval
+	 */
+	protected static JsonNode fromUri(URI uri, RunContext context) throws Exception {
+		Resource res = new UriResource(uri, ResourceType.JSON);
+		Credential crd = PayloadParserFactory.of(res).parse(res, context);
+		return crd.getJson();
 	}
 
 }

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/payload/PngParser.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/payload/PngParser.java
@@ -3,6 +3,8 @@ package org.oneedtech.inspect.vc.payload;
 import static org.oneedtech.inspect.util.code.Defensives.checkTrue;
 
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
@@ -62,9 +64,25 @@ public final class PngParser extends PayloadParser {
 
 			vcString = vcString.trim();
 			if(vcString.charAt(0) != '{'){
-				//This is a jwt.  Fetch either the 'vc' out of the payload and save the string for signature verification.
-				jwtString = vcString;
-				vcNode = fromJwt(vcString, ctx);
+				// check if the content is an URI and we allow URI location in value
+				if (credentialKey.allowsUriLocationInValue()) {
+					try {
+						/** Legacy PNGs in OB 2.0
+						 * The pre-specified behavior of badge baking worked differently.
+						 * Instead of baking the whole assertion or signature into an iTXt:openbadges chunk,
+						 * the URL pointing to the hosted assertion was baked into a tEXt:openbadges chunk.
+						 * In order to get the full assertion, an additional HTTP request must be made after
+						 * extracting the URL from the tEXt chunk.
+						 */
+						URI uri = new URI(vcString);
+						vcNode = fromUri(uri, ctx);
+					} catch (URISyntaxException ignored) {
+						//This is a jwt.  Fetch either the 'vc' out of the payload and save the string for signature verification.
+						jwtString = vcString;
+						vcNode = fromJwt(vcString, ctx);
+					}
+				}
+
 			}
 			else {
 				vcNode = fromString(vcString, ctx);
@@ -105,18 +123,24 @@ public final class PngParser extends PayloadParser {
 	}
 
 	public enum Keys {
-		OB20("openbadges"),
-		OB30("openbadgecredential"),
-		CLR20("clrcredential");
+		OB20("openbadges", true),
+		OB30("openbadgecredential", false),
+		CLR20("clrcredential", false);
 
 		private String nodeName;
+		private boolean allowUriLocationInValue;
 
-		private Keys(String nodeName) {
+		private Keys(String nodeName, boolean allowUriLocationInValue) {
 			this.nodeName = nodeName;
+			this.allowUriLocationInValue = allowUriLocationInValue;
 		}
 
 		public String getNodeName() {
 			return nodeName;
+		}
+
+		public boolean allowsUriLocationInValue() {
+			return allowUriLocationInValue;
 		}
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.1edtech</groupId>
   <artifactId>vc-public-validator</artifactId>
-  <version>1.4.1</version>
+  <version>1.4.2</version>
   <name>vc-public-validator</name>
   <packaging>pom</packaging>
   <developers>
@@ -239,7 +239,7 @@
       <dependency>
         <groupId>com.networknt</groupId>
         <artifactId>json-schema-validator</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
       </dependency>
 
       <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->


### PR DESCRIPTION
This pull request primarily updates project dependencies to version 1.4.2 and introduces enhanced support for parsing credentials from URIs within PNG files. The key change is enabling legacy Open Badges 2.0 PNGs to be processed when they contain a URI to the hosted assertion, improving compatibility and parsing flexibility.

**Dependency version updates:**

* Updated the parent project and `json-schema-validator` dependency versions from 1.4.1 to 1.4.2 in `pom.xml`, `inspector-clr/pom.xml`, `inspector-vc-web/pom.xml`, and `inspector-vc/pom.xml`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L10-R10) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L242-R242) [[3]](diffhunk://#diff-19bc71d15ac3071811e5c0144a622a0d96369a62efbbba0f0236b334fb854ccdL8-R8) [[4]](diffhunk://#diff-fc5de3c5d9d5ffbbeaa45585389b5da045bc73a03516ebf65c926832239f4429L9-R9) [[5]](diffhunk://#diff-bdb9b1be994556dea665c6690e2b82840b5918025609833003c68d3a17c0e2c1L8-R8)

**Credential parsing enhancements:**

* Added support in `PayloadParser` for parsing JSON payloads directly from a URI, enabling retrieval and parsing of credentials hosted at remote locations. [[1]](diffhunk://#diff-b1d096c36292965251d58c9e57bea3f9392ebbc97944c858659bda98fecbe5ecR69-R87) [[2]](diffhunk://#diff-b1d096c36292965251d58c9e57bea3f9392ebbc97944c858659bda98fecbe5ecR5) [[3]](diffhunk://#diff-b1d096c36292965251d58c9e57bea3f9392ebbc97944c858659bda98fecbe5ecR14)
* Enhanced `PngParser` to detect when the extracted credential value is a URI (for OB 2.0 legacy PNGs) and fetch the full assertion via HTTP if allowed by the credential key.
* Updated the `Keys` enum in `PngParser` to specify which credential types allow URI location in their value and added a method to check this property.