### PR TITLE
test: fix @Nested static class not recognized by JUnit (fixes #39)

### DIFF
--- a/inspector-vc/src/test/java/org/oneedtech/inspect/vc/OB20Tests.java
+++ b/inspector-vc/src/test/java/org/oneedtech/inspect/vc/OB20Tests.java
@@ -296,7 +296,7 @@ public class OB20Tests {
 	}
 
 	@Nested
-	static class WarningTests {
+    class WarningTests {
 		@BeforeAll
 		static void setup() throws URISyntaxException {
 			TestBuilder builder = new TestBuilder();


### PR DESCRIPTION
Remove `static` keyword from `@Nested` inner classes in OB20Tests, 
which was causing JUnit inspection warnings.

**Changes:**
- `@Nested static class` → `@Nested class`

**Testing:**
- `mvn clean verify` passes

Fixes #39
