### PR TITLE
fix: update identifier check logic in CredentialSubjectProbe to handl…

### DIFF
--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/CredentialSubjectProbe.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/CredentialSubjectProbe.java
@@ -130,10 +130,8 @@ public class CredentialSubjectProbe extends Probe<JsonNode> {
     JsonNode id = root.get("id");
     if (id != null && id.textValue().strip().length() > 0) return false;
 
-    JsonNode identifier = root.get("identifier");
-    if (identifier != null
-        && identifier instanceof ArrayNode
-        && ((ArrayNode) identifier).size() > 0) return false;
+    List<JsonNode> identifiers = JsonNodeUtil.asNodeList(root.get("identifier"));
+    if (identifiers == null || identifiers.size() > 0) return false;
 
     return true;
   }


### PR DESCRIPTION
This pull request makes a minor logic change in the `idAndIdentifierEmpty` method of `CredentialSubjectProbe.java`. The update modifies how the presence of the `identifier` field is checked, using a utility method and adjusting the logic to improve robustness.

- Logic update for identifier field checking:
  * Replaced direct array and type checking of the `identifier` field with the `JsonNodeUtil.asNodeList` utility method, and updated the conditional to return `false` if the resulting list is either `null` or non-empty.…e array nodes