### PR TITLE
Hotfix/verification method array bug

### DIFF
--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/CredentialSubjectProbe.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/CredentialSubjectProbe.java
@@ -1,13 +1,14 @@
 package org.oneedtech.inspect.vc.probe;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.util.List;
 import java.util.Optional;
+
 import org.oneedtech.inspect.core.probe.Probe;
 import org.oneedtech.inspect.core.probe.RunContext;
 import org.oneedtech.inspect.core.report.ReportItems;
 import org.oneedtech.inspect.vc.util.JsonNodeUtil;
+
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * A Probe that checks credential subject specifics not capturable by schemata.

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <log4j.version>2.23.1</log4j.version>
     <skipTests>false</skipTests>
 		<web3j.version>4.13.0</web3j.version>
-    <public.core.version>1.2.1</public.core.version>
+    <public.core.version>1.2.2</public.core.version>
     <com.danubetech.verifiable.credentials.version>1.18.0</com.danubetech.verifiable.credentials.version>
     <cbor-java.version>0.9</cbor-java.version>
     <!-- <iron.verifiable.credentials.version>0.14.0</iron.verifiable.credentials.version> -->


### PR DESCRIPTION
This pull request enhances the handling of verification methods in the `EmbeddedProofProbe` class and updates a dependency version in `pom.xml`. The most significant changes improve robustness when processing different structures of the `verificationMethod` field in key documents, ensuring compatibility with both arrays and objects.

### Verification Method Handling Improvements

* In `EmbeddedProofProbe.java`, added logic to dynamically check if the `verificationMethod` field in a key document is an array or object, and extract the correct controller and public key based on the expected verification method type. This increases compatibility with a wider range of DID Document formats.
* Introduced a variable `expectedVerifactionMethodType` to distinguish between `Ed25519VerificationKey2020` and `MultiKey` types based on the proof type, improving type validation during verification.

### Dependency Update

* Updated the `public.core.version` in `pom.xml` from `1.2.1` to `1.2.2`, ensuring the project uses the latest compatible version of the core library.

### Code Organization

* Refactored import statements in both `CredentialSubjectProbe.java` and `EmbeddedProofProbe.java` to improve code clarity and maintainability. [[1]](diffhunk://#diff-75da04ad11bc28c0a4c14923e494d76deb97e7193649bfc4b3b90d1065a6a028L3-R12) [[2]](diffhunk://#diff-ef10a6011ba994b7c856f173d0631470270173174f44be6c6ce7077346398b21R3-L7) [[3]](diffhunk://#diff-ef10a6011ba994b7c856f173d0631470270173174f44be6c6ce7077346398b21L21-L33)