### PR TITLE
fix: resolve NullPointerException when didResolver is null in BitstringStatusListCredentialInspector

### DIFF
--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/BitstringStatusListCredentialInspector.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/BitstringStatusListCredentialInspector.java
@@ -26,6 +26,7 @@ import org.oneedtech.inspect.vc.probe.EmbeddedProofProbe;
 import org.oneedtech.inspect.vc.probe.RunContextKey;
 import org.oneedtech.inspect.vc.probe.TypePropertyProbe;
 import org.oneedtech.inspect.vc.probe.did.DidResolver;
+import org.oneedtech.inspect.vc.probe.did.SimpleDidResolver;
 
 public class BitstringStatusListCredentialInspector extends VCInspector {
   private DidResolver didResolver;
@@ -34,6 +35,9 @@ public class BitstringStatusListCredentialInspector extends VCInspector {
       BitstringStatusListCredentialInspector.Builder builder) {
     super(builder);
     this.didResolver = (DidResolver) builder.getInjected(RunContextKey.DID_RESOLVER).orElse(null);
+    if (this.didResolver == null) {
+      this.didResolver = new SimpleDidResolver(null, null);
+    }
   }
 
   @Override


### PR DESCRIPTION
## Summary

Fixes #49

When a credential contains a `credentialStatus` with `BitstringStatusList`, the `BitstringStatusListCredentialInspector` is invoked as a sub-inspector from `BitstringStatusListProbe`. However, the `DID_RESOLVER` is not propagated through the injection mechanism, causing `builder.getInjected(RunContextKey.DID_RESOLVER)` to return `Optional.empty()`.

This results in `this.didResolver` being `null`, which is then passed to the `RunContext`. When `EmbeddedProofProbe` later attempts to resolve the DID to verify the signature of the status list credential, it throws a `NullPointerException`.

## Changes

**File:** `inspector-vc/src/main/java/org/oneedtech/inspect/vc/BitstringStatusListCredentialInspector.java`

- Added import for `SimpleDidResolver`
- Added null check after the existing `getInjected()` call: if the resolver is null, fall back to `new SimpleDidResolver(null, null)` which natively supports `did:web` resolution

## How to reproduce

1. Create a valid OB3 credential with `credentialStatus` pointing to a `BitstringStatusListCredential`
2. Validate it using `OB30Inspector` via `/api/validate?validatorId=OB30Inspector`
3. The validator fetches the status list credential URL, then tries to verify its signature
4. **Before fix:** `NullPointerException` because `didResolver` is null
5. **After fix:** Uses `SimpleDidResolver` as fallback, resolves the DID, and verifies the signature successfully

## Testing

We have been running this fix in production at [validador.unicreda.com](https://validador.unicreda.com) (self-hosted instance) since March 2026, validating hundreds of OB3 credentials with BitstringStatusList without issues.