### PR TITLE
52 statuslistcredential   could not detect credential payload type

### DIFF
--- a/inspector-clr/pom.xml
+++ b/inspector-clr/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
 		<artifactId>vc-public-validator</artifactId>
-		<version>1.7.0</version>
+		<version>1.7.1</version>
 	</parent>
 	<artifactId>inspector-clr</artifactId>
 	<dependencies>

--- a/inspector-clr/src/main/java/org/oneedtech/inspect/clr/CLR20Inspector.java
+++ b/inspector-clr/src/main/java/org/oneedtech/inspect/clr/CLR20Inspector.java
@@ -7,7 +7,7 @@ import static org.oneedtech.inspect.core.report.ReportUtil.onProbeException;
 import static org.oneedtech.inspect.util.json.ObjectMapperCache.Config.DEFAULT;
 import static org.oneedtech.inspect.vc.Credential.CREDENTIAL_KEY;
 import static org.oneedtech.inspect.vc.VCInspector.InjectionKeys.*;
-import static org.oneedtech.inspect.vc.VerifiableCredential.REFRESH_SERVICE_MIME_TYPES;
+import static org.oneedtech.inspect.vc.VerifiableCredential.REFRESH_SERVICE_RESOURCE_TYPES;
 import static org.oneedtech.inspect.vc.VerifiableCredential.ProofType.EXTERNAL;
 import static org.oneedtech.inspect.vc.payload.PayloadParser.fromJwt;
 import static org.oneedtech.inspect.vc.util.JsonNodeUtil.asNodeList;
@@ -181,7 +181,7 @@ public class CLR20Inspector extends VCInspector {
 				Optional<String> newID = checkRefreshService(clr, ctx);
 				if(newID.isPresent()) {
 					// If the refresh is not successful, continue the verification process using the original OpenBadgeCredential.
-					UriResource uriResource = new UriResource(new URI(newID.get()), null, REFRESH_SERVICE_MIME_TYPES);
+					UriResource uriResource = new UriResource(new URI(newID.get()), null, REFRESH_SERVICE_RESOURCE_TYPES);
 					if (uriResource.exists()) {
 						accumulator.add(this.run(uriResource.setContext(new ResourceContext(REFRESHED, TRUE))));
 					}

--- a/inspector-clr/src/main/java/org/oneedtech/inspect/clr/CLR20Inspector.java
+++ b/inspector-clr/src/main/java/org/oneedtech/inspect/clr/CLR20Inspector.java
@@ -169,7 +169,7 @@ public class CLR20Inspector extends VCInspector {
 			probeCount++;
 			if(clr.getProofType() == EXTERNAL){
 				//The credential originally contained in a JWT, validate the jwt and external proof.
-				accumulator.add(new ExternalProofProbe().run(clr, ctx));
+				accumulator.add(new ExternalProofProbe(false).run(clr, ctx));
 			} else {
 				accumulator.add(new EmbeddedProofProbe().run(clr, ctx));
 			}

--- a/inspector-vc-web/pom.xml
+++ b/inspector-vc-web/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
         <artifactId>vc-public-validator</artifactId>
-		<version>1.7.0</version>
+		<version>1.7.1</version>
 	</parent>
 	<artifactId>inspector-vc-web</artifactId>
 	<properties>

--- a/inspector-vc/pom.xml
+++ b/inspector-vc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
 		<artifactId>vc-public-validator</artifactId>
-		<version>1.7.0</version>
+		<version>1.7.1</version>
 	</parent>
 	<artifactId>inspector-vc</artifactId>
 

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/BitstringStatusListCredentialInspector.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/BitstringStatusListCredentialInspector.java
@@ -18,11 +18,13 @@ import org.oneedtech.inspect.util.json.ObjectMapperCache;
 import org.oneedtech.inspect.util.resource.Resource;
 import org.oneedtech.inspect.util.resource.ResourceType;
 import org.oneedtech.inspect.util.spec.Specification;
+import org.oneedtech.inspect.vc.VerifiableCredential.ProofType;
 import org.oneedtech.inspect.vc.VerifiableCredential.Type;
 import org.oneedtech.inspect.vc.probe.ContextPropertyProbe;
 import org.oneedtech.inspect.vc.probe.CredentialParseProbe;
 import org.oneedtech.inspect.vc.probe.CredentialSubjectProbe;
 import org.oneedtech.inspect.vc.probe.EmbeddedProofProbe;
+import org.oneedtech.inspect.vc.probe.ExternalProofProbe;
 import org.oneedtech.inspect.vc.probe.RunContextKey;
 import org.oneedtech.inspect.vc.probe.TypePropertyProbe;
 import org.oneedtech.inspect.vc.probe.did.DidResolver;
@@ -54,6 +56,7 @@ public class BitstringStatusListCredentialInspector extends VCInspector {
             .put(Key.JACKSON_OBJECTMAPPER, mapper)
             .put(Key.JSONPATH_EVALUATOR, jsonPath)
             .put(Key.GENERATED_OBJECT_BUILDER, new VerifiableCredential.Builder())
+            .put(Key.JWT_CREDENTIAL_NODE_NAME, "vc")
             .put(RunContextKey.DID_RESOLVER, didResolver)
             .build();
 
@@ -86,7 +89,14 @@ public class BitstringStatusListCredentialInspector extends VCInspector {
 
       // proof
       probeCount++;
-      accumulator.add(new EmbeddedProofProbe().run(bslCred, ctx));
+      if (bslCred.getProofType() == ProofType.EXTERNAL) {
+        // The credential originally contained in a JWT, validate the jwt and external proof.
+        accumulator.add(new ExternalProofProbe(true).run(bslCred, ctx));
+      } else {
+        // The credential not contained in a jwt, must have an internal proof.
+        accumulator.add(new EmbeddedProofProbe().run(bslCred, ctx));
+      }
+      if (broken(accumulator)) return abort(ctx, accumulator, probeCount);
 
       // add the credential as a generated object
       accumulator.add(new ReportItems(Collections.emptyList(), List.of(bslCred)));

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/Credential.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/Credential.java
@@ -6,6 +6,8 @@ import static org.oneedtech.inspect.util.resource.ResourceType.JSON;
 import static org.oneedtech.inspect.util.resource.ResourceType.JWT;
 import static org.oneedtech.inspect.util.resource.ResourceType.PNG;
 import static org.oneedtech.inspect.util.resource.ResourceType.SVG;
+import static org.oneedtech.inspect.util.resource.ResourceType.VC_JSON_LD;
+import static org.oneedtech.inspect.util.resource.ResourceType.VC_JWT;
 
 import java.util.List;
 import java.util.Map;
@@ -84,7 +86,7 @@ public abstract class Credential extends GeneratedObject {
 				.toString();
 	}
 
-	public static final List<ResourceType> RECOGNIZED_PAYLOAD_TYPES = List.of(SVG, PNG, JSON, JWT);
+	public static final List<ResourceType> RECOGNIZED_PAYLOAD_TYPES = List.of(SVG, PNG, JSON, JWT, VC_JSON_LD, VC_JWT);
 	public static final String CREDENTIAL_KEY = "CREDENTIAL_KEY";
 
     public interface CredentialEnum {

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/EndorsementInspector.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/EndorsementInspector.java
@@ -11,7 +11,7 @@ import static org.oneedtech.inspect.util.code.Defensives.checkNotNull;
 import static org.oneedtech.inspect.util.json.ObjectMapperCache.Config.DEFAULT;
 import static org.oneedtech.inspect.vc.Credential.CREDENTIAL_KEY;
 import static org.oneedtech.inspect.vc.VCInspector.InjectionKeys.*;
-import static org.oneedtech.inspect.vc.VerifiableCredential.REFRESH_SERVICE_MIME_TYPES;
+import static org.oneedtech.inspect.vc.VerifiableCredential.REFRESH_SERVICE_RESOURCE_TYPES;
 import static org.oneedtech.inspect.vc.VerifiableCredential.ProofType.EXTERNAL;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -160,7 +160,7 @@ public class EndorsementInspector extends VCInspector implements SubInspector {
           // If the refresh is not successful, continue the verification process using the original
           // EndorsementCredential.
           UriResource uriResource =
-              new UriResource(new URI(newID.get()), null, REFRESH_SERVICE_MIME_TYPES);
+              new UriResource(new URI(newID.get()), null, REFRESH_SERVICE_RESOURCE_TYPES);
           if (uriResource.exists()) {
             return this.run(uriResource.setContext(new ResourceContext(REFRESHED, TRUE)));
           }
@@ -244,7 +244,7 @@ public class EndorsementInspector extends VCInspector implements SubInspector {
       probeCount++;
       if (endorsement.getProofType() == EXTERNAL) {
         // The credential originally contained in a JWT, validate the jwt and external proof.
-        accumulator.add(new ExternalProofProbe().run(endorsement, ctx));
+        accumulator.add(new ExternalProofProbe(false).run(endorsement, ctx));
       } else {
         accumulator.add(new EmbeddedProofProbe().run(endorsement, ctx));
       }

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/EndorsementInspector.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/EndorsementInspector.java
@@ -145,7 +145,7 @@ public class EndorsementInspector extends VCInspector implements SubInspector {
       probeCount++;
       if (endorsement.getProofType() == EXTERNAL) {
         // The credential originally contained in a JWT, validate the jwt and external proof.
-        accumulator.add(new ExternalProofProbe().run(endorsement, ctx));
+        accumulator.add(new ExternalProofProbe(false).run(endorsement, ctx));
       } else {
         // The credential not contained in a jwt, must have an internal proof.
         accumulator.add(new EmbeddedProofProbe().run(endorsement, ctx));

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/OB30Inspector.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/OB30Inspector.java
@@ -9,7 +9,7 @@ import static org.oneedtech.inspect.util.json.ObjectMapperCache.Config.DEFAULT;
 import static org.oneedtech.inspect.vc.Credential.CREDENTIAL_KEY;
 import static org.oneedtech.inspect.vc.VCInspector.InjectionKeys.*;
 import static org.oneedtech.inspect.vc.VerifiableCredential.ProofType.EXTERNAL;
-import static org.oneedtech.inspect.vc.VerifiableCredential.REFRESH_SERVICE_MIME_TYPES;
+import static org.oneedtech.inspect.vc.VerifiableCredential.REFRESH_SERVICE_RESOURCE_TYPES;
 import static org.oneedtech.inspect.vc.payload.PayloadParser.fromJwt;
 import static org.oneedtech.inspect.vc.util.JsonNodeUtil.asNodeList;
 
@@ -266,7 +266,7 @@ public class OB30Inspector extends VCInspector implements SubInspector {
           // If the refresh is not successful, continue the verification process using the original
           // OpenBadgeCredential.
           UriResource uriResource =
-              new UriResource(new URI(newID.get()), null, REFRESH_SERVICE_MIME_TYPES);
+              new UriResource(new URI(newID.get()), null, REFRESH_SERVICE_RESOURCE_TYPES);
           if (uriResource.exists()) {
             accumulator.add(this.run(uriResource.setContext(new ResourceContext(REFRESHED, TRUE))));
           }

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/OB30Inspector.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/OB30Inspector.java
@@ -251,7 +251,7 @@ public class OB30Inspector extends VCInspector implements SubInspector {
       probeCount++;
       if (ob.getProofType() == EXTERNAL) {
         // The credential originally contained in a JWT, validate the jwt and external proof.
-        accumulator.add(new ExternalProofProbe().run(ob, ctx));
+        accumulator.add(new ExternalProofProbe(false).run(ob, ctx));
       } else {
         // The credential not contained in a jwt, must have an internal proof.
         accumulator.add(new EmbeddedProofProbe().run(ob, ctx));

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/VerifiableCredential.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/VerifiableCredential.java
@@ -5,18 +5,20 @@ import static org.oneedtech.inspect.vc.VerifiableCredential.Type.ClrCredential;
 import static org.oneedtech.inspect.vc.VerifiableCredential.Type.EndorsementCredential;
 import static org.oneedtech.inspect.vc.VerifiableCredential.Type.VerifiablePresentation;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import org.oneedtech.inspect.schema.Catalog;
 import org.oneedtech.inspect.schema.SchemaKey;
-import org.oneedtech.inspect.util.resource.MimeType;
 import org.oneedtech.inspect.util.resource.Resource;
+import org.oneedtech.inspect.util.resource.ResourceType;
 import org.oneedtech.inspect.vc.util.JsonNodeUtil;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * A wrapper object for a verifiable credential. This contains e.g. the origin resource and the
@@ -233,6 +235,6 @@ public class VerifiableCredential extends Credential {
   private static final String EXPIRES_AT_PROPERTY_NAME_V20 = "validUntil";
   public static final String JWT_NODE_NAME = "vc";
   public static final Boolean JWT_ALLOW_WHOLE_PAYLOAD = true;
-  public static final List<MimeType> REFRESH_SERVICE_MIME_TYPES =
-      List.of(MimeType.JSON, MimeType.JSON_LD, MimeType.TEXT_PLAIN);
+  public static final List<ResourceType> REFRESH_SERVICE_RESOURCE_TYPES =
+      List.of(ResourceType.VC_JSON_LD, ResourceType.JSON_LD, ResourceType.JSON, ResourceType.VC_JWT, ResourceType.JWT, ResourceType.PNG, ResourceType.SVG);
 }

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/payload/JsonParser.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/payload/JsonParser.java
@@ -18,12 +18,12 @@ public final class JsonParser extends PayloadParser {
 
 	@Override
 	public boolean supports(ResourceType type) {
-		return type == ResourceType.JSON;
+		return type == ResourceType.JSON || type == ResourceType.VC_JSON_LD || type == ResourceType.JSON_LD;
 	}
 
 	@Override
 	public Credential parse(Resource resource, RunContext ctx)  throws Exception {
-		checkTrue(resource.getType() == ResourceType.JSON);
+		checkTrue(resource.getType() == ResourceType.JSON || resource.getType() == ResourceType.VC_JSON_LD || resource.getType() == ResourceType.JSON_LD);
 		String json = resource.asByteSource().asCharSource(UTF_8).read();
 		JsonNode node = fromString(json, ctx);
 

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/payload/JwtParser.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/payload/JwtParser.java
@@ -18,12 +18,12 @@ public final class JwtParser extends PayloadParser {
 
 	@Override
 	public boolean supports(ResourceType type) {
-		return type == ResourceType.JWT;
+		return type == ResourceType.JWT || type == ResourceType.VC_JWT;
 	}
 
 	@Override
 	public Credential parse(Resource resource, RunContext ctx)  throws Exception {
-		checkTrue(resource.getType() == ResourceType.JWT);
+		checkTrue(resource.getType() == ResourceType.JWT || resource.getType() == ResourceType.VC_JWT);
 		String jwt = resource.asByteSource().asCharSource(UTF_8).read();
 		JsonNode node = fromJwt(jwt, ctx);
 		return getBuilder(ctx)

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/ExternalProofProbe.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/ExternalProofProbe.java
@@ -4,6 +4,7 @@ import static org.oneedtech.inspect.util.code.Defensives.checkTrue;
 
 import java.math.BigInteger;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.security.AlgorithmParameters;
 import java.security.KeyFactory;
 import java.security.interfaces.ECPublicKey;
@@ -30,6 +31,7 @@ import org.oneedtech.inspect.core.probe.RunContext;
 import org.oneedtech.inspect.core.report.ReportItems;
 import org.oneedtech.inspect.vc.VerifiableCredential;
 import org.oneedtech.inspect.vc.probe.did.DidResolution;
+import org.oneedtech.inspect.vc.probe.did.DidResolutionException;
 import org.oneedtech.inspect.vc.probe.did.DidResolver;
 import org.oneedtech.inspect.vc.util.CachingDocumentLoader;
 
@@ -51,8 +53,11 @@ import com.google.common.base.Splitter;
  */
 public class ExternalProofProbe extends Probe<VerifiableCredential> {
 
-	public ExternalProofProbe() {
+	private final boolean allowKidAsHint;
+
+	public ExternalProofProbe(boolean allowKidAsHint) {
 		super(ID);
+		this.allowKidAsHint = allowKidAsHint;
 	}
 
 	@Override
@@ -99,12 +104,15 @@ public class ExternalProofProbe extends Probe<VerifiableCredential> {
 		JsonNode kid = headerObj.get("kid");
 
 		if(jwk == null && kid == null) { throw new Exception("Key must present in either jwk or kid value."); }
-		if(kid != null){
+		if(kid != null) {
+			// check if kid can be a hint to the jwk in dids as defined in https://www.w3.org/TR/vc-jose-cose/#kid
+			boolean kidAsHint = kidCanBeUsedAsHint(kid.textValue(), crd);
+
 			//Load jwk JsonNode from url and do the rest the same below.
 			//TODO Consider additional testing.
 			String kidUrl = kid.textValue();
 			try {
-				String jwkResponse = fetchJwk(kidUrl, ctx);
+				String jwkResponse = fetchJwk(kidUrl, kidAsHint, crd, ctx);
 				jwk = mapper.readTree(jwkResponse);
 			} catch (Exception e) {
 				throw new Exception("Unable to retrieve jwk value from url specified in kid.", e);
@@ -170,11 +178,15 @@ public class ExternalProofProbe extends Probe<VerifiableCredential> {
 		}
 	}
 
-	private String fetchJwk(String fetchUrl, RunContext ctx) throws Exception{
+	private String fetchJwk(String fetchUrl, boolean kidAsHint, VerifiableCredential crd, RunContext ctx) throws Exception {
         String responseString = null;
 
 		URI kidUri = new URI(fetchUrl);
 		if (kidUri.getScheme() == null || kidUri.getScheme().equals("did")) {
+			if (kidUri.getScheme() == null && kidAsHint) {
+				// if the kid value is not a URI, treat it as a fragment and try to resolve it as a did with the kid as hint
+				return fetchJwkFromDidUsingKidAsHint(fetchUrl, crd, ctx);
+			}
 			DidResolver didResolver = ctx.get(RunContextKey.DID_RESOLVER);
 			DidResolution didResolution = didResolver.resolve(kidUri, new CachingDocumentLoader()); // Not using the default document loader options
 			responseString = didResolution.getPublicKeyJwk();
@@ -206,4 +218,39 @@ public class ExternalProofProbe extends Probe<VerifiableCredential> {
 
 	public static final String ID = ExternalProofProbe.class.getSimpleName();
 
+	private boolean kidCanBeUsedAsHint(String kid, VerifiableCredential crd) {
+		if(!allowKidAsHint) return false;
+		// check if kid can be a hint to the jwk in dids as defined in https://www.w3.org/TR/vc-jose-cose/#kid
+		// this is a very basic check that looks for the kid value as a fragment in the credential issuer's DID URL. More complex logic could be added here if needed.
+		if(!crd.getJson().hasNonNull("issuer")) return false;
+		String issuer = getIssuerId(crd);
+		return issuer.startsWith("did:");
+	}
+
+	private String fetchJwkFromDidUsingKidAsHint(String kid, VerifiableCredential crd, RunContext ctx) throws DidResolutionException, URISyntaxException {
+		// get issuer id from credential
+		String issuer = getIssuerId(crd);
+
+		// resolve issuer did
+        DidResolver didResolver = ctx.get(RunContextKey.DID_RESOLVER);
+          DidResolution didResolution =
+              didResolver.resolve(new URI(issuer + "#" + kid), new CachingDocumentLoader()); // Not using the default document loader options
+        return didResolution.getPublicKeyJwk();
+	}
+
+	private String getIssuerId(VerifiableCredential crd) {
+		// issuer node can be either a string or an object with id property. Check both.
+		if(!crd.getJson().hasNonNull("issuer")) {
+			throw new IllegalArgumentException("Credential issuer is required but was not found.");
+		}
+
+		JsonNode issuerNode = crd.getJson().get("issuer");
+		if(issuerNode.isTextual()) {
+			return issuerNode.asText();
+		} else if(issuerNode.isObject() && issuerNode.get("id") != null && issuerNode.get("id").isTextual()) {
+			return issuerNode.get("id").asText();
+		} else {
+			throw new IllegalArgumentException("Credential issuer is required but was not found.");
+		}
+	}
 }

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/resource/DefaultJsonLDUriResourceFactory.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/resource/DefaultJsonLDUriResourceFactory.java
@@ -4,7 +4,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 
-import org.oneedtech.inspect.util.resource.MimeType;
 import org.oneedtech.inspect.util.resource.ResourceType;
 import org.oneedtech.inspect.util.resource.UriResource;
 
@@ -12,7 +11,7 @@ public class DefaultJsonLDUriResourceFactory implements UriResourceFactory {
 
     @Override
     public UriResource of(String uri) throws URISyntaxException {
-        return new UriResource(new URI(uri), ResourceType.JSON, List.of(MimeType.JSON_LD, MimeType.JSON));
+        return new UriResource(new URI(uri), ResourceType.JSON, List.of(ResourceType.VC_JSON_LD, ResourceType.JSON_LD, ResourceType.JSON));
     }
 
 }

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/status/bitstring/BitstringStatusListProbe.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/status/bitstring/BitstringStatusListProbe.java
@@ -1,7 +1,5 @@
 package org.oneedtech.inspect.vc.status.bitstring;
 
-import com.apicatalog.multibase.MultibaseDecoder;
-import com.fasterxml.jackson.databind.JsonNode;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -9,16 +7,20 @@ import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 import java.util.zip.GZIPInputStream;
+
 import org.oneedtech.inspect.core.probe.Outcome;
 import org.oneedtech.inspect.core.probe.Probe;
 import org.oneedtech.inspect.core.probe.RunContext;
 import org.oneedtech.inspect.core.report.Report;
 import org.oneedtech.inspect.core.report.ReportItems;
-import org.oneedtech.inspect.util.resource.MimeType;
+import org.oneedtech.inspect.util.resource.ResourceType;
 import org.oneedtech.inspect.util.resource.UriResource;
 import org.oneedtech.inspect.vc.BitstringStatusListCredentialInspector;
 import org.oneedtech.inspect.vc.VerifiableCredential;
 import org.oneedtech.inspect.vc.probe.RunContextKey;
+
+import com.apicatalog.multibase.MultibaseDecoder;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * Follows algorithm defined at https://w3c.github.io/vc-bitstring-status-list/#validate-algorithm
@@ -51,7 +53,8 @@ public class BitstringStatusListProbe extends Probe<JsonNode> {
       return error("statusListCredential is not a valid URI", ctx);
     }
     UriResource uriResource =
-        new UriResource(statusListCredentialUrl, null, List.of(MimeType.JSON, MimeType.JSON_LD));
+        new UriResource(statusListCredentialUrl, null, List.of(ResourceType.JSON,
+						ResourceType.JSON_LD, ResourceType.JWT, ResourceType.VC_JSON_LD, ResourceType.VC_JWT));
 
     BitstringStatusListCredentialInspector inspector =
         new BitstringStatusListCredentialInspector.Builder()

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.1edtech</groupId>
   <artifactId>vc-public-validator</artifactId>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
   <name>vc-public-validator</name>
   <packaging>pom</packaging>
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <log4j.version>2.23.1</log4j.version>
     <skipTests>false</skipTests>
 		<web3j.version>4.13.0</web3j.version>
-    <public.core.version>1.4.0</public.core.version>
+    <public.core.version>1.5.1</public.core.version>
     <com.danubetech.verifiable.credentials.version>1.18.0</com.danubetech.verifiable.credentials.version>
     <cbor-java.version>0.9</cbor-java.version>
     <!-- <iron.verifiable.credentials.version>0.14.0</iron.verifiable.credentials.version> -->


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the credential inspection modules, focusing on better support for new resource types, more robust handling of external proofs, and improved refresh service logic. The most significant changes include expanding recognized credential formats, updating refresh service resource handling, and enhancing the logic for external proof validation.

**Resource Type and Format Support:**

* Expanded recognized payload types in `Credential` to include `VC_JSON_LD` and `VC_JWT`, in addition to existing formats. This allows the system to handle a broader range of verifiable credential representations.
* Updated `JsonParser` and `JwtParser` to support parsing new resource types (`VC_JSON_LD`, `VC_JWT`, and `JSON_LD`), improving compatibility with different credential formats. [[1]](diffhunk://#diff-f24e192facd83ff42349475134c340776df5ee8d87b9b26e56e133487982de07L21-R26) [[2]](diffhunk://#diff-aac8659c73ad6fbda9bb0e69ac45c42493ea0f7b1c928169e5ee42c7fcd541b2L21-R26)

**Refresh Service Handling:**

* Changed the refresh service logic to use `REFRESH_SERVICE_RESOURCE_TYPES` (a list of `ResourceType`), replacing the previous use of MIME types. This ensures that refresh operations are compatible with all relevant credential formats and resource types. [[1]](diffhunk://#diff-599c6929ec54be10fbf8c05d6612696df7582b1afeac53ae5fda42f8232316b4L236-R239) [[2]](diffhunk://#diff-026c492a2d1161cf1a629cfd5f43fb54a41daffdf61479d400635ec1e3f17127L10-R10) [[3]](diffhunk://#diff-026c492a2d1161cf1a629cfd5f43fb54a41daffdf61479d400635ec1e3f17127L184-R184) [[4]](diffhunk://#diff-e9c9a1546690fed16566346bd9d3ad63edcbfdacebb1c4e564af2708488302adL14-R14) [[5]](diffhunk://#diff-e9c9a1546690fed16566346bd9d3ad63edcbfdacebb1c4e564af2708488302adL163-R163) [[6]](diffhunk://#diff-246a0ba1452661936f8a3b0ce1d4076e914e2b540c0b16783ccbfbd38b5de0d6L12-R12) [[7]](diffhunk://#diff-246a0ba1452661936f8a3b0ce1d4076e914e2b540c0b16783ccbfbd38b5de0d6L269-R269)

**External Proof Validation:**

* Refactored `ExternalProofProbe` to accept a boolean `allowKidAsHint` parameter, enabling or disabling the use of the `kid` field as a hint for resolving keys, in accordance with the VC-JOSE-COSE specification. Updated all relevant inspectors to pass the correct value. [[1]](diffhunk://#diff-7e29923b8bed201d201595534d77281671ea1d38a1c8b6c8ad338e4eea65cb73L54-R60) [[2]](diffhunk://#diff-7e29923b8bed201d201595534d77281671ea1d38a1c8b6c8ad338e4eea65cb73R108-R115) [[3]](diffhunk://#diff-7e29923b8bed201d201595534d77281671ea1d38a1c8b6c8ad338e4eea65cb73L173-R189) [[4]](diffhunk://#diff-026c492a2d1161cf1a629cfd5f43fb54a41daffdf61479d400635ec1e3f17127L172-R172) [[5]](diffhunk://#diff-e9c9a1546690fed16566346bd9d3ad63edcbfdacebb1c4e564af2708488302adL148-R148) [[6]](diffhunk://#diff-e9c9a1546690fed16566346bd9d3ad63edcbfdacebb1c4e564af2708488302adL247-R247) [[7]](diffhunk://#diff-246a0ba1452661936f8a3b0ce1d4076e914e2b540c0b16783ccbfbd38b5de0d6L254-R254) [[8]](diffhunk://#diff-0553637c8bea43b8ed8daa6811cd8e553e4a7028b16754771e2387688a7db73dR92-R99)
* Improved logic in `ExternalProofProbe` to handle cases where the `kid` value may be used as a fragment/hint when resolving DIDs, increasing compatibility with various credential issuers. [[1]](diffhunk://#diff-7e29923b8bed201d201595534d77281671ea1d38a1c8b6c8ad338e4eea65cb73R108-R115) [[2]](diffhunk://#diff-7e29923b8bed201d201595534d77281671ea1d38a1c8b6c8ad338e4eea65cb73L173-R189)

**Dependency and Build Updates:**

* Bumped the parent project version to `1.7.1` in all relevant `pom.xml` files to ensure consistency and pick up upstream changes. [[1]](diffhunk://#diff-19bc71d15ac3071811e5c0144a622a0d96369a62efbbba0f0236b334fb854ccdL8-R8) [[2]](diffhunk://#diff-bdb9b1be994556dea665c6690e2b82840b5918025609833003c68d3a17c0e2c1L8-R8) [[3]](diffhunk://#diff-fc5de3c5d9d5ffbbeaa45585389b5da045bc73a03516ebf65c926832239f4429L9-R9)

**Inspector Logic Improvements:**

* Added context property for JWT credential node name in `BitstringStatusListCredentialInspector` to ensure correct processing of JWT-encoded credentials.
* Various import cleanups and reordering for clarity and maintainability. [[1]](diffhunk://#diff-599c6929ec54be10fbf8c05d6612696df7582b1afeac53ae5fda42f8232316b4L8-R22) [[2]](diffhunk://#diff-0553637c8bea43b8ed8daa6811cd8e553e4a7028b16754771e2387688a7db73dR21-R27) [[3]](diffhunk://#diff-7e29923b8bed201d201595534d77281671ea1d38a1c8b6c8ad338e4eea65cb73R7) [[4]](diffhunk://#diff-7e29923b8bed201d201595534d77281671ea1d38a1c8b6c8ad338e4eea65cb73R34)

These changes collectively improve the flexibility, standards compliance, and reliability of the credential inspection modules.