### PR TITLE
fix: set JWT_CREDENTIAL_ALLOW_WHOLE_PAYLOAD in BitstringStatusListCredentialInspector

### DIFF
--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/BitstringStatusListCredentialInspector.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/BitstringStatusListCredentialInspector.java
@@ -56,7 +56,8 @@ public class BitstringStatusListCredentialInspector extends VCInspector {
             .put(Key.JACKSON_OBJECTMAPPER, mapper)
             .put(Key.JSONPATH_EVALUATOR, jsonPath)
             .put(Key.GENERATED_OBJECT_BUILDER, new VerifiableCredential.Builder())
-            .put(Key.JWT_CREDENTIAL_NODE_NAME, "vc")
+            .put(Key.JWT_CREDENTIAL_NODE_NAME, VerifiableCredential.JWT_NODE_NAME)
+            .put(Key.JWT_CREDENTIAL_ALLOW_WHOLE_PAYLOAD, VerifiableCredential.JWT_ALLOW_WHOLE_PAYLOAD)
             .put(RunContextKey.DID_RESOLVER, didResolver)
             .build();
 


### PR DESCRIPTION
Fixes #57.
  
Sets `JWT_CREDENTIAL_ALLOW_WHOLE_PAYLOAD` in BitstringStatusListCredentialInspector to support also VCDM 2.0 model in BitstringStatusListCredential