### PR TITLE
fix: upgrade dependencies to resolve critical and high security vulnerabilities

### DIFF
--- a/inspector-clr/pom.xml
+++ b/inspector-clr/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
 		<artifactId>vc-public-validator</artifactId>
-		<version>1.9.1</version>
+		<version>1.10.0</version>
 	</parent>
 	<artifactId>inspector-clr</artifactId>
 	<dependencies>

--- a/inspector-tcp-vc/pom.xml
+++ b/inspector-tcp-vc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
 		<artifactId>vc-public-validator</artifactId>
-		<version>1.9.1</version>
+		<version>1.10.0</version>
 	</parent>
 	<artifactId>inspector-tcp-vc</artifactId>
 	<dependencies>

--- a/inspector-vc-web/pom.xml
+++ b/inspector-vc-web/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
         <artifactId>vc-public-validator</artifactId>
-		<version>1.9.1</version>
+		<version>1.10.0</version>
 	</parent>
 	<artifactId>inspector-vc-web</artifactId>
 	<properties>

--- a/inspector-vc/pom.xml
+++ b/inspector-vc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
 		<artifactId>vc-public-validator</artifactId>
-		<version>1.9.1</version>
+		<version>1.10.0</version>
 	</parent>
 	<artifactId>inspector-vc</artifactId>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>17</java.version>
-    <log4j.version>2.23.1</log4j.version>
+    <log4j.version>2.25.3</log4j.version>
     <skipTests>false</skipTests>
 		<web3j.version>4.13.0</web3j.version>
     <public.core.version>1.7.5</public.core.version>
@@ -232,14 +232,14 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.18.3</version>
+        <version>2.18.7</version>
       </dependency>
 
       <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jdk8 -->
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jdk8</artifactId>
-        <version>2.18.3</version>
+        <version>2.18.7</version>
       </dependency>
 
       <!-- https://mvnrepository.com/artifact/com.jayway.jsonpath/json-path -->
@@ -310,7 +310,17 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk18on</artifactId>
-        <version>1.80</version>
+        <version>1.84</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk18on</artifactId>
+        <version>1.84</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcutil-jdk18on</artifactId>
+        <version>1.84</version>
       </dependency>
 
       <!-- https://github.com/danubetech/verifiable-credentials-java -->
@@ -337,6 +347,37 @@
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>logging-interceptor</artifactId>
         <version>4.9.3</version>
+      </dependency>
+
+      <!-- Netty BOM to override vulnerable transitive versions from web3j/aws-sdk -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>4.1.133.Final</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- Override vulnerable transitive dependencies -->
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.18.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bitcoinj</groupId>
+        <artifactId>bitcoinj-core</artifactId>
+        <version>0.17.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.upokecenter</groupId>
+        <artifactId>cbor</artifactId>
+        <version>4.5.2</version>
+      </dependency>
+      <dependency>
+        <groupId>net.minidev</groupId>
+        <artifactId>json-smart</artifactId>
+        <version>2.4.9</version>
       </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>17</java.version>
-    <log4j.version>2.25.3</log4j.version>
+    <log4j.version>2.25.4</log4j.version>
     <skipTests>false</skipTests>
 		<web3j.version>4.13.0</web3j.version>
     <public.core.version>1.7.5</public.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <log4j.version>2.25.4</log4j.version>
     <skipTests>false</skipTests>
 		<web3j.version>4.13.0</web3j.version>
-    <public.core.version>1.7.5</public.core.version>
+    <public.core.version>1.8.0</public.core.version>
     <com.danubetech.verifiable.credentials.version>1.18.0</com.danubetech.verifiable.credentials.version>
     <cbor-java.version>0.9</cbor-java.version>
     <!-- <iron.verifiable.credentials.version>0.14.0</iron.verifiable.credentials.version> -->

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.1edtech</groupId>
   <artifactId>vc-public-validator</artifactId>
-  <version>1.9.1</version>
+  <version>1.10.0</version>
   <name>vc-public-validator</name>
   <packaging>pom</packaging>
   <developers>


### PR DESCRIPTION
## Summary
- Upgrades direct and transitive dependencies in `pom.xml` to resolve **34 of 45** Snyk-reported security vulnerabilities, including **all 1 critical and 21 of 22 high-severity issues**
- The sole remaining high is a `jnr-posix` license compliance issue (EPL/GPL/LGPL) requiring legal review, not a code fix

## Dependency Upgrades

| Package | From | To | Vulns Fixed |
|---------|------|----|-------------|
| `org.bouncycastle:bcprov-jdk18on` | 1.80 | 1.84 | 1 critical + 2 high |
| `org.bouncycastle:bcpkix-jdk18on` | 1.77 (transitive) | 1.84 | (included above) |
| `io.netty:netty-bom` | — | 4.1.133.Final | 10 high |
| `com.fasterxml.jackson.core:jackson-databind` | 2.18.3 | 2.18.7 | 2 high |
| `org.apache.logging.log4j:log4j-*` | 2.23.1 | 2.25.4 | 3 high (CVE-2026-34478, CVE-2026-34479, CVE-2026-34480) |
| `org.apache.commons:commons-lang3` | 3.17.0 (transitive) | 3.18.0 | 1 high |
| `org.bitcoinj:bitcoinj-core` | 0.17 (transitive) | 0.17.1 | 1 high |
| `net.minidev:json-smart` | 2.4.7 (transitive) | 2.4.9 | 1 high |
| `com.upokecenter:cbor` | — (transitive) | 4.5.2 | 1 high |

## Test plan
- [x] `mvn clean test` — all modules build and pass
- [x] `snyk test --file=inspector-vc/pom.xml` — confirms 0 critical, 1 high (license only), 7 medium, 3 low
- [ ] Verify no runtime regressions in deployed environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)