### PR TITLE
Fix index calculation, set fail-fast behavior, and update versions

### DIFF
--- a/inspector-clr/pom.xml
+++ b/inspector-clr/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
 		<artifactId>vc-public-validator</artifactId>
-		<version>1.10.3</version>
+		<version>1.11.0</version>
 	</parent>
 	<artifactId>inspector-clr</artifactId>
 	<dependencies>

--- a/inspector-tcp-vc/pom.xml
+++ b/inspector-tcp-vc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
 		<artifactId>vc-public-validator</artifactId>
-		<version>1.10.3</version>
+		<version>1.11.0</version>
 	</parent>
 	<artifactId>inspector-tcp-vc</artifactId>
 	<dependencies>

--- a/inspector-vc-web/pom.xml
+++ b/inspector-vc-web/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
         <artifactId>vc-public-validator</artifactId>
-		<version>1.10.3</version>
+		<version>1.11.0</version>
 	</parent>
 	<artifactId>inspector-vc-web</artifactId>
 	<properties>

--- a/inspector-vc/pom.xml
+++ b/inspector-vc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.1edtech</groupId>
 		<artifactId>vc-public-validator</artifactId>
-		<version>1.10.3</version>
+		<version>1.11.0</version>
 	</parent>
 	<artifactId>inspector-vc</artifactId>
 

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/VCInspector.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/VCInspector.java
@@ -1,5 +1,6 @@
 package org.oneedtech.inspect.vc;
 
+import static java.lang.Boolean.TRUE;
 import static java.util.stream.Collectors.toList;
 import static org.oneedtech.inspect.vc.util.JsonNodeUtil.asStringList;
 
@@ -19,7 +20,6 @@ import org.oneedtech.inspect.core.report.ReportItems;
 import org.oneedtech.inspect.util.code.Tuple;
 import org.oneedtech.inspect.vc.jsonld.probe.ExtensionProbe;
 import org.oneedtech.inspect.vc.resource.DefaultJsonLDUriResourceFactory;
-import org.oneedtech.inspect.vc.resource.DefaultUriResourceFactory;
 import org.oneedtech.inspect.vc.resource.UriResourceFactory;
 import org.oneedtech.inspect.vc.util.CachingDocumentLoader;
 import org.oneedtech.inspect.vc.util.JsonNodeUtil;
@@ -135,6 +135,8 @@ public abstract class VCInspector extends Inspector {
 		public Builder() {
 			super();
 			this.probes = new ArrayList<>();
+			// default to fail fast on json schema validation errors
+			this.set(Inspector.Behavior.JsonSchema.VALIDATOR_FAIL_FAST, TRUE);
 		}
 
 		public VCInspector.Builder<B> add(Probe<VerifiableCredential> probe) {

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/VerifiableCredential.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/VerifiableCredential.java
@@ -58,14 +58,14 @@ public class VerifiableCredential extends Credential {
     return version;
   }
 
-  private static final Map<CredentialEnum, SchemaKey> schemas =
-      new ImmutableMap.Builder<CredentialEnum, SchemaKey>()
-          .put(AchievementCredential, Catalog.OB_30_ANY_ACHIEVEMENTCREDENTIAL_JSON)
-          .put(OpenBadgeCredential, Catalog.OB_30_ANY_ACHIEVEMENTCREDENTIAL_JSON)
-          .put(ClrCredential, Catalog.CLR_20_ANY_CLRCREDENTIAL_JSON)
-          .put(VerifiablePresentation, Catalog.CLR_20_ANY_CLRCREDENTIAL_JSON)
-          .put(EndorsementCredential, Catalog.OB_30_ANY_ENDORSEMENTCREDENTIAL_JSON)
-          .build();
+  // private static final Map<CredentialEnum, SchemaKey> schemas =
+  //     new ImmutableMap.Builder<CredentialEnum, SchemaKey>()
+  //         .put(AchievementCredential, Catalog.OB_30_ANY_ACHIEVEMENTCREDENTIAL_JSON)
+  //         .put(OpenBadgeCredential, Catalog.OB_30_ANY_ACHIEVEMENTCREDENTIAL_JSON)
+  //         .put(ClrCredential, Catalog.CLR_20_ANY_CLRCREDENTIAL_JSON)
+  //         .put(VerifiablePresentation, Catalog.CLR_20_ANY_CLRCREDENTIAL_JSON)
+  //         .put(EndorsementCredential, Catalog.OB_30_ANY_ENDORSEMENTCREDENTIAL_JSON)
+  //         .build();
 
   private static final Map<CredentialEnum, List<String>> proofTypes =
       new ImmutableMap.Builder<CredentialEnum, List<String>>()
@@ -226,15 +226,33 @@ public class VerifiableCredential extends Credential {
   }
 
   public static enum VCVersion {
-    VCDMv2p0(ISSUED_ON_PROPERTY_NAME_V20, EXPIRES_AT_PROPERTY_NAME_V20),
-    VCDMv1p1(ISSUED_ON_PROPERTY_NAME_V11, EXPIRES_AT_PROPERTY_NAME_V11);
+    VCDMv2p0(
+        ISSUED_ON_PROPERTY_NAME_V20,
+        EXPIRES_AT_PROPERTY_NAME_V20,
+        new ImmutableMap.Builder<CredentialEnum, SchemaKey>()
+            .put(AchievementCredential, Catalog.OB_30_ACHIEVEMENTCREDENTIAL_JSON)
+            .put(ClrCredential, Catalog.CLR_20_CLRCREDENTIAL_JSON)
+            .put(VerifiablePresentation, Catalog.CLR_20_CLRCREDENTIAL_JSON)
+            .put(EndorsementCredential, Catalog.OB_30_ENDORSEMENTCREDENTIAL_JSON)
+            .build()),
+    VCDMv1p1(
+        ISSUED_ON_PROPERTY_NAME_V11,
+        EXPIRES_AT_PROPERTY_NAME_V11,
+        new ImmutableMap.Builder<CredentialEnum, SchemaKey>()
+            .put(AchievementCredential, Catalog.OB_30_ANY_ACHIEVEMENTCREDENTIAL_JSON)
+            .put(ClrCredential, Catalog.CLR_20_ANY_CLRCREDENTIAL_JSON)
+            .put(VerifiablePresentation, Catalog.CLR_20_ANY_CLRCREDENTIAL_JSON)
+            .put(EndorsementCredential, Catalog.OB_30_ANY_ENDORSEMENTCREDENTIAL_JSON)
+            .build());
 
     final String issuanceDateField;
     final String expirationDateField;
+    final Map<CredentialEnum, SchemaKey> schemas;
 
-    VCVersion(String issuanceDateField, String expirationDateField) {
+    VCVersion(String issuanceDateField, String expirationDateField, Map<CredentialEnum, SchemaKey> schemas) {
       this.issuanceDateField = issuanceDateField;
       this.expirationDateField = expirationDateField;
+      this.schemas = schemas;
     }
 
     public static VCVersion of(JsonNode context) {
@@ -260,7 +278,7 @@ public class VerifiableCredential extends Credential {
     public VerifiableCredential build() {
       VCVersion version = VCVersion.of(getJsonData().get("@context"));
 
-      return new VerifiableCredential(getResource(), getJsonData(), getJwt(), schemas, version);
+      return new VerifiableCredential(getResource(), getJsonData(), getJwt(), version.schemas, version);
     }
   }
 

--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/status/bitstring/BitstringStatusListProbe.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/status/bitstring/BitstringStatusListProbe.java
@@ -117,7 +117,7 @@ public class BitstringStatusListProbe extends Probe<JsonNode> {
       // multiplied by the size. If the credentialIndex multiplied by the size is a value outside of
       // the range of the bitstring, a RANGE_ERROR MUST be raised.
       int index = credentialIndex * statusSize;
-      if (index >= revocationBitString.length) {
+      if (index >= revocationBitString.length * 8L) {
         return error(
             "credentialIndex multiplied by the size is a value outside of the range of the"
                 + " bitstring",

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.1edtech</groupId>
   <artifactId>vc-public-validator</artifactId>
-  <version>1.10.3</version>
+  <version>1.11.0</version>
   <name>vc-public-validator</name>
   <packaging>pom</packaging>
   <developers>
@@ -23,7 +23,8 @@
     <log4j.version>2.25.4</log4j.version>
     <skipTests>false</skipTests>
 		<web3j.version>4.13.0</web3j.version>
-    <public.core.version>1.8.3</public.core.version>
+    <public.core.version>1.9.0</public.core.version>
+		<jackson.version>2.18.7</jackson.version>
     <com.danubetech.verifiable.credentials.version>1.18.0</com.danubetech.verifiable.credentials.version>
     <cbor-java.version>0.9</cbor-java.version>
     <!-- <iron.verifiable.credentials.version>0.14.0</iron.verifiable.credentials.version> -->
@@ -232,28 +233,28 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.18.7</version>
+				<version>${jackson.version}</version>
       </dependency>
 
       <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jdk8 -->
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jdk8</artifactId>
-        <version>2.18.7</version>
+				<version>${jackson.version}</version>
       </dependency>
 
       <!-- https://mvnrepository.com/artifact/com.jayway.jsonpath/json-path -->
       <dependency>
         <groupId>com.jayway.jsonpath</groupId>
         <artifactId>json-path</artifactId>
-        <version>2.7.0</version>
+				<version>2.9.0</version>
       </dependency>
 
       <!-- https://mvnrepository.com/artifact/com.networknt/json-schema-validator -->
       <dependency>
         <groupId>com.networknt</groupId>
         <artifactId>json-schema-validator</artifactId>
-        <version>1.4.2</version>
+        <version>1.4.3</version>
       </dependency>
 
       <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
@@ -280,7 +281,7 @@
       <dependency>
         <groupId>net.sf.saxon</groupId>
         <artifactId>Saxon-HE</artifactId>
-        <version>9.5.1-5</version>
+				<version>9.6.0-4</version>
       </dependency>
 
 


### PR DESCRIPTION
This pull request updates dependencies and refactors schema handling for Verifiable Credentials. The most significant changes are the introduction of version-specific schema mappings in `VCVersion`, dependency upgrades throughout the project, and a bug fix in status list processing.

### Schema Handling Improvements

* Refactored `VerifiableCredential.java` to move schema mappings into the `VCVersion` enum, allowing each version to specify its own set of schemas. This replaces the previous static `schemas` map and ensures that the correct schema is used based on the credential version. [[1]](diffhunk://#diff-599c6929ec54be10fbf8c05d6612696df7582b1afeac53ae5fda42f8232316b4L61-R68) [[2]](diffhunk://#diff-599c6929ec54be10fbf8c05d6612696df7582b1afeac53ae5fda42f8232316b4L229-R255) [[3]](diffhunk://#diff-599c6929ec54be10fbf8c05d6612696df7582b1afeac53ae5fda42f8232316b4L263-R281). Fixes #35 

### Dependency Upgrades

* Bumped the parent POM and module versions from `1.10.3` to `1.11.0` in `pom.xml` and all module POMs to ensure consistency and pull in the latest features and fixes. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L10-R10) [[2]](diffhunk://#diff-19bc71d15ac3071811e5c0144a622a0d96369a62efbbba0f0236b334fb854ccdL8-R8) [[3]](diffhunk://#diff-d0c373352edf75b4a212769bfd56bd4a4907d615bf938412a635f8c021e0ba70L8-R8) [[4]](diffhunk://#diff-fc5de3c5d9d5ffbbeaa45585389b5da045bc73a03516ebf65c926832239f4429L9-R9) [[5]](diffhunk://#diff-bdb9b1be994556dea665c6690e2b82840b5918025609833003c68d3a17c0e2c1L8-R8)
* Updated core dependencies, including `public.core.version` to `1.9.0`, `jackson.version` to `2.18.7`, `json-path` to `2.9.0`, `json-schema-validator` to `1.4.3`, and `Saxon-HE` to `9.6.0-4` for improved compatibility and bug fixes. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L26-R27) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L235-R257) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L283-R284)

### Bug Fixes

* Fixed a bug in `BitstringStatusListProbe.java` where the range check for `credentialIndex` was not correctly accounting for the bitstring size in bits, preventing potential out-of-range errors.

### Default Behavior Change

* Set the default behavior in `VCInspector.Builder` to fail fast on JSON schema validation errors, improving error detection during credential inspection.

### Code Cleanup

* Removed an unused import in `VCInspector.java` for better code hygiene.