### PR TITLE
fix: treat an absent identifier as empty in CredentialSubjectProbe

### DIFF
--- a/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/CredentialSubjectProbe.java
+++ b/inspector-vc/src/main/java/org/oneedtech/inspect/vc/probe/CredentialSubjectProbe.java
@@ -132,7 +132,7 @@ public class CredentialSubjectProbe extends Probe<JsonNode> {
     if (id != null && id.textValue().strip().length() > 0) return false;
 
     List<JsonNode> identifiers = JsonNodeUtil.asNodeList(root.get("identifier"));
-    if (identifiers == null || identifiers.size() > 0) return false;
+    if (identifiers != null && identifiers.size() > 0) return false;
 
     return true;
   }

--- a/inspector-vc/src/test/java/org/oneedtech/inspect/vc/OB30Tests.java
+++ b/inspector-vc/src/test/java/org/oneedtech/inspect/vc/OB30Tests.java
@@ -346,6 +346,17 @@ public class OB30Tests {
 	}
 
 	@Test
+	void testSimpleJsonCredentialSubjectWithoutIdOrIdentifier() {
+		//remove .id and .identifier, either of which the spec requires
+		assertDoesNotThrow(()->{
+			Report report = validator.run(Samples.OB30.JSON.SIMPLE_JSON_CREDENTIAL_SUBJECT_NO_ID_NO_IDENTIFIER.asFileResource());
+			if(verbose) PrintHelper.print(report, true);
+			assertInvalid(report);
+			assertHasProbeID(report, CredentialSubjectProbe.ID, true);
+		});
+	}
+
+	@Test
 	void testSimpleJsonInvalidCredentialSubjectResultType() {
 		//add a dumb value to .type and remove the ob type
 		assertDoesNotThrow(()->{

--- a/inspector-vc/src/test/java/org/oneedtech/inspect/vc/Samples.java
+++ b/inspector-vc/src/test/java/org/oneedtech/inspect/vc/Samples.java
@@ -23,6 +23,7 @@ public class Samples {
 			public final static Sample SIMPLE_JSON_UNKNOWN_TYPE = new Sample("ob30/simple-err-type.json", false);
 			public final static Sample SIMPLE_JSON_UNKNOWN_CREDENTIAL_SUBJECT_TYPE = new Sample("ob30/simple-err-credential-subject-type.json", false);
 			public final static Sample SIMPLE_JSON_UNKNOWN_CREDENTIAL_SUBJECT_IDENTIFIER_TYPE = new Sample("ob30/simple-err-credential-subject-identifier-type.json", false);
+			public final static Sample SIMPLE_JSON_CREDENTIAL_SUBJECT_NO_ID_NO_IDENTIFIER = new Sample("ob30/simple-err-credential-subject-no-id-no-identifier.json", false);
 			public final static Sample SIMPLE_JSON_UNKNOWN_CREDENTIAL_SUBJECT_RESULT_TYPE = new Sample("ob30/simple-err-credential-subject-result-type.json", false);
 			public final static Sample SIMPLE_JSON_UNKNOWN_CREDENTIAL_SUBJECT_ACHIEVEMENT_RESULT_DESCRIPTION_TYPE = new Sample("ob30/simple-err-credential-subject-achievement-result-description-type.json", false);
 			public final static Sample SIMPLE_JSON_UNKNOWN_CREDENTIAL_SUBJECT_PROFILE_TYPE = new Sample("ob30/simple-err-credential-subject-profile-type.json", false);

--- a/inspector-vc/src/test/resources/ob30/simple-err-credential-subject-no-id-no-identifier.json
+++ b/inspector-vc/src/test/resources/ob30/simple-err-credential-subject-no-id-no-identifier.json
@@ -1,0 +1,44 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json"
+  ],
+  "id": "http://example.com/credentials/3527",
+  "type": [
+    "VerifiableCredential",
+    "OpenBadgeCredential"
+  ],
+  "issuer": {
+    "id": "https://example.com/issuers/876543",
+    "type": [
+      "Profile"
+    ],
+    "name": "Example Corp"
+  },
+  "validFrom": "2010-01-01T00:00:00Z",
+  "name": "Teamwork Badge",
+  "credentialSubject": {
+    "type": [
+      "AchievementSubject"
+    ],
+    "achievement": {
+      "id": "https://example.com/achievements/21st-century-skills/teamwork",
+      "type": [
+        "Achievement"
+      ],
+      "criteria": {
+        "narrative": "Team members are nominated for this badge by their peers and recognized upon review by Example Corp management."
+      },
+      "description": "This badge recognizes the development of the capacity to collaborate within a group environment.",
+      "name": "Teamwork"
+    }
+  },
+  "proof": {
+    "type": "DataIntegrityProof",
+    "created": "2010-01-01T19:23:24Z",
+    "verificationMethod": "https://example.com/issuers/876543#z6MkjZRZv3aez3r18pB1RBFJR1kwUVJ5jHt92JmQwXbd5hwi",
+    "cryptosuite": "eddsa-rdfc-2022",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z5M8kUcxhKZ8niHpZt1LUBLrJGeLMnYaCmwrdR7MrcGzyiGz65zkk59212f7xpd7odxGVDp4e6MvNABsQ8YGn7U98"
+  }
+}


### PR DESCRIPTION
A `credentialSubject` with neither `id` nor `identifier` currently validates as VALID. OB 3.0 §B.1.3 says "Either `id` or at least one `identifier` MUST be supplied", and the JSON Schema does not encode that constraint, so `CredentialSubjectProbe` is the only place it is enforced.

**Cause**

#46 swapped the inline array check for `JsonNodeUtil.asNodeList`, which returns `null` when the field is absent:

```java
List<JsonNode> identifiers = JsonNodeUtil.asNodeList(root.get("identifier"));
if (identifiers == null || identifiers.size() > 0) return false;
```

A missing `identifier` takes the `null` branch and reports the subject as populated — the opposite of what the method's own comment says it checks ("Check that we have either .id or .identifier populated"). The check only fires today when `identifier` is written out as a literal `[]`.

#46 was about accepting a non-array `identifier`, and `asNodeList` still does that. Only the null case moves, back to what it did before #46.

**Change:** `identifiers == null ||` → `identifiers != null &&`

| `id` | `identifier` | before | after |
|---|---|---|---|
| present | any | pass | pass |
| absent | array with entries | pass | pass |
| absent | single non-array node | pass | pass |
| absent | absent | **pass** | error |
| absent | `[]` | error | error |

`EndorsementInspector` builds this probe through the one-argument constructor, which defaults `identifierRequired` to true, so endorsements see the same change. `BitstringStatusListCredentialInspector` passes false and is unaffected, and OB 2.0 does not use this probe.

**Testing**

Added `simple-err-credential-subject-no-id-no-identifier.json`, copied from the existing identifier-type fixture with `identifier` removed. There was no fixture for the absent case, which is why the suite did not catch this.

Before the fix, `testSimpleJsonCredentialSubjectWithoutIdOrIdentifier` fails with `did not find probe id CredentialSubjectProbe`; after it, the probe reports `no id in credentialSubject`. `mvn -pl inspector-vc -am test` passes, 98 tests.
